### PR TITLE
Update Delegate Output

### DIFF
--- a/AnyImageKit.xcodeproj/project.pbxproj
+++ b/AnyImageKit.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		A04B044723B1A54F00DA4D47 /* Capture.strings in Resources */ = {isa = PBXBuildFile; fileRef = A04B044923B1A54F00DA4D47 /* Capture.strings */; };
 		A04B045423B1B1E700DA4D47 /* Capture.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A04B045323B1B1E700DA4D47 /* Capture.xcassets */; };
 		A04EACCB2385250D004A9795 /* Core+Notification.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04EACCA2385250D004A9795 /* Core+Notification.swift */; };
+		A0513A152521A0030069C5CB /* CaptureResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0513A142521A0030069C5CB /* CaptureResult.swift */; };
 		A05C8DA3233DEFD7005B0F3C /* PickerManager+Photo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A05C8DA2233DEFD7005B0F3C /* PickerManager+Photo.swift */; };
 		A05C8DA7233DFC71005B0F3C /* PickerManager+Album.swift in Sources */ = {isa = PBXBuildFile; fileRef = A05C8DA6233DFC71005B0F3C /* PickerManager+Album.swift */; };
 		A0604E7123307ABD00D9AA01 /* Picker+PHFetchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0604E7023307ABD00D9AA01 /* Picker+PHFetchResult.swift */; };
@@ -278,6 +279,7 @@
 		A04B045223B1AB8D00DA4D47 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Core.strings"; sourceTree = "<group>"; };
 		A04B045323B1B1E700DA4D47 /* Capture.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Capture.xcassets; sourceTree = "<group>"; };
 		A04EACCA2385250D004A9795 /* Core+Notification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Core+Notification.swift"; sourceTree = "<group>"; };
+		A0513A142521A0030069C5CB /* CaptureResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureResult.swift; sourceTree = "<group>"; };
 		A0514F02235D455600D4AA0F /* AnyImageKit.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = AnyImageKit.podspec; sourceTree = "<group>"; };
 		A05C8DA2233DEFD7005B0F3C /* PickerManager+Photo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PickerManager+Photo.swift"; sourceTree = "<group>"; };
 		A05C8DA6233DFC71005B0F3C /* PickerManager+Album.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PickerManager+Album.swift"; sourceTree = "<group>"; };
@@ -574,6 +576,7 @@
 			isa = PBXGroup;
 			children = (
 				A56123A223B5F43B0071C3E8 /* CaptureOptionsInfo.swift */,
+				A0513A142521A0030069C5CB /* CaptureResult.swift */,
 				A076999823963D3B0006AC9B /* Controller */,
 				A08DF7BA23B1F7BA002B92EE /* Model */,
 				A07699A123963F560006AC9B /* View */,
@@ -1396,6 +1399,7 @@
 				A01F15CF23CC38A800F41097 /* DeviceIOComponent.swift in Sources */,
 				A0B22EAD237AA1B3001F6066 /* ScreenHelper.swift in Sources */,
 				A0B50C3623A9EDDC002C9799 /* Capture+CGImage.swift in Sources */,
+				A0513A152521A0030069C5CB /* CaptureResult.swift in Sources */,
 				A50B211B237AA24300A894A9 /* EditorEditOptionsView.swift in Sources */,
 				A00869BD233C987600237651 /* AssociatedObject.swift in Sources */,
 				A09D15A3239E0FEF00F3FE77 /* CaptureButton.swift in Sources */,

--- a/AnyImageKit.xcodeproj/project.pbxproj
+++ b/AnyImageKit.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		A0147E0623C45A2C0071E9D5 /* Permission+Microphone.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0147E0523C45A2C0071E9D5 /* Permission+Microphone.swift */; };
 		A0147E0C23C4870D0071E9D5 /* AnyImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0147E0B23C4870D0071E9D5 /* AnyImageViewController.swift */; };
 		A01866F1239F8740002E623D /* CapturePreviewMaskView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01866F0239F8740002E623D /* CapturePreviewMaskView.swift */; };
+		A01A59372522206A00FABD22 /* EditorResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01A59362522206A00FABD22 /* EditorResult.swift */; };
 		A01C582923B33C7A00691F11 /* Palette.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01C582823B33C7A00691F11 /* Palette.swift */; };
 		A01C582B23B33CB200691F11 /* Core+UIDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01C582A23B33CB200691F11 /* Core+UIDevice.swift */; };
 		A01C582D23B33CCA00691F11 /* DebugHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01C582C23B33CCA00691F11 /* DebugHelper.swift */; };
@@ -255,6 +256,7 @@
 		A0147E0523C45A2C0071E9D5 /* Permission+Microphone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Permission+Microphone.swift"; sourceTree = "<group>"; };
 		A0147E0B23C4870D0071E9D5 /* AnyImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyImageViewController.swift; sourceTree = "<group>"; };
 		A01866F0239F8740002E623D /* CapturePreviewMaskView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturePreviewMaskView.swift; sourceTree = "<group>"; };
+		A01A59362522206A00FABD22 /* EditorResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorResult.swift; sourceTree = "<group>"; };
 		A01C582823B33C7A00691F11 /* Palette.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Palette.swift; sourceTree = "<group>"; };
 		A01C582A23B33CB200691F11 /* Core+UIDevice.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Core+UIDevice.swift"; sourceTree = "<group>"; };
 		A01C582C23B33CCA00691F11 /* DebugHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DebugHelper.swift; sourceTree = "<group>"; };
@@ -855,6 +857,7 @@
 				71CBF1462519CF1400F79D19 /* EditorOptionsInfo.swift */,
 				A561239C23B5EE400071C3E8 /* EditorPhotoOptionsInfo.swift */,
 				A561239E23B5EE4F0071C3E8 /* EditorVideoOptionsInfo.swift */,
+				A01A59362522206A00FABD22 /* EditorResult.swift */,
 				A50B20D4237AA24200A894A9 /* Controller */,
 				A50B20D8237AA24200A894A9 /* Model */,
 				A50B20E6237AA24200A894A9 /* View */,
@@ -1307,6 +1310,7 @@
 				A08DF7C523B3326C002B92EE /* CaptureToolView.swift in Sources */,
 				A0800411232F4EE4006B4711 /* ImagePickerController.swift in Sources */,
 				A50B2116237AA24300A894A9 /* EditorMosaicToolView.swift in Sources */,
+				A01A59372522206A00FABD22 /* EditorResult.swift in Sources */,
 				A5DF1E84237AA32C00E3A32E /* Editor+UIView.swift in Sources */,
 				A5EFE3F9237D3E060071F39F /* PhotoPreviewController+Editor.swift in Sources */,
 				A50B2108237AA24200A894A9 /* BezierGenerator.swift in Sources */,

--- a/AnyImageKit.xcodeproj/project.pbxproj
+++ b/AnyImageKit.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		A0147E0C23C4870D0071E9D5 /* AnyImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0147E0B23C4870D0071E9D5 /* AnyImageViewController.swift */; };
 		A01866F1239F8740002E623D /* CapturePreviewMaskView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01866F0239F8740002E623D /* CapturePreviewMaskView.swift */; };
 		A01A59372522206A00FABD22 /* EditorResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01A59362522206A00FABD22 /* EditorResult.swift */; };
+		A01A593B2522297600FABD22 /* PickerResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01A593A2522297600FABD22 /* PickerResult.swift */; };
 		A01C582923B33C7A00691F11 /* Palette.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01C582823B33C7A00691F11 /* Palette.swift */; };
 		A01C582B23B33CB200691F11 /* Core+UIDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01C582A23B33CB200691F11 /* Core+UIDevice.swift */; };
 		A01C582D23B33CCA00691F11 /* DebugHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01C582C23B33CCA00691F11 /* DebugHelper.swift */; };
@@ -257,6 +258,7 @@
 		A0147E0B23C4870D0071E9D5 /* AnyImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyImageViewController.swift; sourceTree = "<group>"; };
 		A01866F0239F8740002E623D /* CapturePreviewMaskView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturePreviewMaskView.swift; sourceTree = "<group>"; };
 		A01A59362522206A00FABD22 /* EditorResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorResult.swift; sourceTree = "<group>"; };
+		A01A593A2522297600FABD22 /* PickerResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickerResult.swift; sourceTree = "<group>"; };
 		A01C582823B33C7A00691F11 /* Palette.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Palette.swift; sourceTree = "<group>"; };
 		A01C582A23B33CB200691F11 /* Core+UIDevice.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Core+UIDevice.swift"; sourceTree = "<group>"; };
 		A01C582C23B33CCA00691F11 /* DebugHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DebugHelper.swift; sourceTree = "<group>"; };
@@ -509,6 +511,7 @@
 			isa = PBXGroup;
 			children = (
 				A561239623B5E7B90071C3E8 /* PickerOptionsInfo.swift */,
+				A01A593A2522297600FABD22 /* PickerResult.swift */,
 				A0800418232F5F90006B4711 /* Controller */,
 				A5A27BBA232F83C900D966B8 /* View */,
 				A0F4753A232F7DDB00BB117B /* Model */,
@@ -1433,6 +1436,7 @@
 				A513C45E23ACA9FC0071D0D5 /* Core+UIImage.swift in Sources */,
 				A56A3C8E2330BCB000EBFC48 /* PickerToolBar.swift in Sources */,
 				A07AC74C23B5EF0E002CB5AF /* Capture+CMFormatDescription.swift in Sources */,
+				A01A593B2522297600FABD22 /* PickerResult.swift in Sources */,
 				A01C582F23B33CE600691F11 /* AnyImageError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/Controller/AvatarPickerController.swift
+++ b/Example/Controller/AvatarPickerController.swift
@@ -74,14 +74,14 @@ final class AvatarPickerController: UITableViewController {
 // MARK: - ImagePickerControllerDelegate
 extension AvatarPickerController: ImagePickerControllerDelegate {
     
-    func imagePicker(_ picker: ImagePickerController, didFinishPicking assets: [Asset], useOriginalImage: Bool) {
+    func imagePicker(_ picker: ImagePickerController, didFinishPicking result: PickerResult) {
         picker.dismiss(animated: false, completion: nil)
         
         var options = EditorPhotoOptionsInfo()
         options.toolOptions = [.crop]
         options.cropOptions = [.custom(w: 1, h: 1)]
         
-        let controller = ImageEditorController(photo: assets.first!.image, options: options, delegate: self)
+        let controller = ImageEditorController(photo: result.assets.first!.image, options: options, delegate: self)
         controller.modalPresentationStyle = .fullScreen
         present(controller, animated: false, completion: nil)
     }

--- a/Example/Controller/AvatarPickerController.swift
+++ b/Example/Controller/AvatarPickerController.swift
@@ -95,9 +95,9 @@ extension AvatarPickerController: ImageEditorControllerDelegate {
         openPickerTapped()
     }
     
-    func imageEditor(_ editor: ImageEditorController, didFinishEditing mediaURL: URL, type: MediaType, isEdited: Bool) {
-        if type == .photo {
-            guard let photoData = try? Data(contentsOf: mediaURL) else { return }
+    func imageEditor(_ editor: ImageEditorController, didFinishEditing result: EditorResult) {
+        if result.type == .photo {
+            guard let photoData = try? Data(contentsOf: result.mediaURL) else { return }
             guard let photo = UIImage(data: photoData) else { return }
             let controller = EditorResultViewController()
             controller.imageView.image = photo

--- a/Example/Controller/CaptureConfigViewController.swift
+++ b/Example/Controller/CaptureConfigViewController.swift
@@ -86,12 +86,12 @@ final class CaptureConfigViewController: UITableViewController {
 // MARK: - ImageCaptureControllerDelegate
 extension CaptureConfigViewController: ImageCaptureControllerDelegate {
     
-    func imageCapture(_ capture: ImageCaptureController, didFinishCapturing mediaURL: URL, type: MediaType) {
-        switch type {
+    func imageCapture(_ capture: ImageCaptureController, didFinishCapturing result: CaptureResult) {
+        switch result.type {
         case .photo:
             capture.dismiss(animated: true, completion: { [weak self] in
                 guard let self = self else { return }
-                guard let data = try? Data(contentsOf: mediaURL) else { return }
+                guard let data = try? Data(contentsOf: result.mediaURL) else { return }
                 guard let image = UIImage(data: data) else { return }
                 let controller = EditorResultViewController()
                 controller.imageView.image = image
@@ -100,7 +100,7 @@ extension CaptureConfigViewController: ImageCaptureControllerDelegate {
         case .video:
             capture.dismiss(animated: true, completion: { [weak self] in
                 guard let self = self else { return }
-                let player = AVPlayer(url: mediaURL)
+                let player = AVPlayer(url: result.mediaURL)
                 let controller = AVPlayerViewController()
                 controller.player = player
                 controller.modalPresentationStyle = .fullScreen

--- a/Example/Controller/EditorConfigViewController.swift
+++ b/Example/Controller/EditorConfigViewController.swift
@@ -86,9 +86,9 @@ final class EditorConfigViewController: UITableViewController {
 // MARK: - ImageEditorPhotoDelegate
 extension EditorConfigViewController: ImageEditorControllerDelegate {
     
-    func imageEditor(_ editor: ImageEditorController, didFinishEditing mediaURL: URL, type: MediaType, isEdited: Bool) {
-        if type == .photo {
-            guard let photoData = try? Data(contentsOf: mediaURL) else { return }
+    func imageEditor(_ editor: ImageEditorController, didFinishEditing result: EditorResult) {
+        if result.type == .photo {
+            guard let photoData = try? Data(contentsOf: result.mediaURL) else { return }
             guard let photo = UIImage(data: photoData) else { return }
             let controller = EditorResultViewController()
             controller.imageView.image = photo

--- a/Example/Controller/PickerConfigViewController.swift
+++ b/Example/Controller/PickerConfigViewController.swift
@@ -90,10 +90,10 @@ final class PickerConfigViewController: UITableViewController {
 // MARK: - ImagePickerControllerDelegate
 extension PickerConfigViewController: ImagePickerControllerDelegate {
     
-    func imagePicker(_ picker: ImagePickerController, didFinishPicking assets: [Asset], useOriginalImage: Bool) {
-        print(assets)
+    func imagePicker(_ picker: ImagePickerController, didFinishPicking result: PickerResult) {
+        print(result.assets)
         let controller = PickerResultViewController()
-        controller.assets = assets
+        controller.assets = result.assets
         show(controller, sender: nil)
         picker.dismiss(animated: true, completion: nil)
     }

--- a/README.md
+++ b/README.md
@@ -91,33 +91,27 @@ Add this key to your Info.plist:
 ```swift
 import AnyImageKit
 
-let controller = ImagePickerController(delegate: self)
-present(controller, animated: true, completion: nil)
+class ViewController: UIViewController {
 
-/// ImagePickerControllerDelegate
-func imagePickerDidCancel(_ picker: ImagePickerController) {
-    // Your code, handle cancel
-    picker.dismiss(animated: true, completion: nil)
+    @IBAction private func openPicker() {
+        let options = PickerOptionsInfo()
+        let controller = ImagePickerController(options: options, delegate: self)
+        present(controller, animated: true, completion: nil)
+    }
 }
+
+extension ViewController: ImagePickerControllerDelegate {
+
+    func imagePickerDidCancel(_ picker: ImagePickerController) {
+        // Your code, handle cancel
+        picker.dismiss(animated: true, completion: nil)
+    }
     
-func imagePicker(_ picker: ImagePickerController, didFinishPicking assets: [Asset], useOriginalImage: Bool) {
-    // Your code, handle select assets
-    let images = assets.map { $0.image }
-    picker.dismiss(animated: true, completion: nil)
-}
-```
-
-### Fetch content data
-```swift
-/// Fetch Video URL 
-/// - Note: Only for `MediaType` Video
-/// - Parameter options: Video URL Fetch Options
-/// - Parameter completion: Video URL Fetch Completion
-func fetchVideoURL(options: VideoURLFetchOptions = .init(), completion: @escaping VideoURLFetchCompletion)
-
-// Call
-asset.fetchVideoURL { (result) in
-    // Your code
+    func imagePicker(_ picker: ImagePickerController, didFinishPicking result: PickerResult) {
+        // Your code, handle select assets
+        let images = result.assets.map { $0.image }
+        picker.dismiss(animated: true, completion: nil)
+    }
 }
 ```
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -85,33 +85,27 @@ github "AnyImageProject/AnyImageKit"
 ```swift
 import AnyImageKit
 
-let controller = ImagePickerController(delegate: self)
-present(controller, animated: true, completion: nil)
+class ViewController: UIViewController {
 
-/// ImagePickerControllerDelegate
-func imagePickerDidCancel(_ picker: ImagePickerController) {
-    // 你的业务代码，处理取消(存在默认实现，如果需要额外行为请自行实现本方法)
-    picker.dismiss(animated: true, completion: nil)
+    @IBAction private func openPicker() {
+        let options = PickerOptionsInfo()
+        let controller = ImagePickerController(options: options, delegate: self)
+        present(controller, animated: true, completion: nil)
+    }
 }
+
+extension ViewController: ImagePickerControllerDelegate {
+
+    func imagePickerDidCancel(_ picker: ImagePickerController) {
+        // Your code, handle cancel
+        picker.dismiss(animated: true, completion: nil)
+    }
     
-func imagePicker(_ picker: ImagePickerController, didFinishPicking assets: [Asset], useOriginalImage: Bool) {
-    // 你的业务代码，处理选中的资源
-    let images = assets.map { $0.image }
-    picker.dismiss(animated: true, completion: nil)
-}
-```
-
-### 获取内容数据
-```swift
-/// Fetch Video URL 
-/// - Note: Only for `MediaType` Video
-/// - Parameter options: Video URL Fetch Options
-/// - Parameter completion: Video URL Fetch Completion
-func fetchVideoURL(options: VideoURLFetchOptions = .init(), completion: @escaping VideoURLFetchCompletion)
-
-// Call
-asset.fetchVideoURL { (result) in
-    // Your code
+    func imagePicker(_ picker: ImagePickerController, didFinishPicking result: PickerResult) {
+        // Your code, handle select assets
+        let images = result.assets.map { $0.image }
+        picker.dismiss(animated: true, completion: nil)
+    }
 }
 ```
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -102,12 +102,12 @@ class ViewController: UIViewController {
 extension ViewController: ImagePickerControllerDelegate {
 
     func imagePickerDidCancel(_ picker: ImagePickerController) {
-        // Your code, handle cancel
+        // 你的业务代码，处理取消(存在默认实现，如果需要额外行为请自行实现本方法)
         picker.dismiss(animated: true, completion: nil)
     }
     
     func imagePicker(_ picker: ImagePickerController, didFinishPicking result: PickerResult) {
-        // Your code, handle select assets
+        // 你的业务代码，处理选中的资源
         let images = result.assets.map { $0.image }
         picker.dismiss(animated: true, completion: nil)
     }

--- a/Sources/AnyImageKit/Capture/CaptureResult.swift
+++ b/Sources/AnyImageKit/Capture/CaptureResult.swift
@@ -1,0 +1,20 @@
+//
+//  CaptureResult.swift
+//  AnyImageKit
+//
+//  Created by 刘栋 on 2020/9/28.
+//  Copyright © 2020 AnyImageProject.org. All rights reserved.
+//
+
+import Foundation
+
+public struct CaptureResult: Equatable {
+    
+    public let mediaURL: URL
+    public let type: MediaType
+    
+    init(mediaURL: URL, type: MediaType) {
+        self.mediaURL = mediaURL
+        self.type = type
+    }
+}

--- a/Sources/AnyImageKit/Capture/Controller/CaptureViewController.swift
+++ b/Sources/AnyImageKit/Capture/Controller/CaptureViewController.swift
@@ -339,8 +339,8 @@ extension CaptureViewController: ImageEditorControllerDelegate {
         editor.dismiss(animated: false, completion: nil)
     }
     
-    func imageEditor(_ editor: ImageEditorController, didFinishEditing mediaURL: URL, type: MediaType, isEdited: Bool) {
-        delegate?.capture(self, didOutput: mediaURL, type: type)
+    func imageEditor(_ editor: ImageEditorController, didFinishEditing result: EditorResult) {
+        delegate?.capture(self, didOutput: result.mediaURL, type: result.type)
     }
 }
 

--- a/Sources/AnyImageKit/Capture/Controller/ImageCaptureController.swift
+++ b/Sources/AnyImageKit/Capture/Controller/ImageCaptureController.swift
@@ -12,7 +12,7 @@ import SnapKit
 public protocol ImageCaptureControllerDelegate: class {
     
     func imageCaptureDidCancel(_ capture: ImageCaptureController)
-    func imageCapture(_ capture: ImageCaptureController, didFinishCapturing mediaURL: URL, type: MediaType)
+    func imageCapture(_ capture: ImageCaptureController, didFinishCapturing result: CaptureResult)
 }
 
 extension ImageCaptureControllerDelegate {
@@ -79,7 +79,8 @@ extension ImageCaptureController: CaptureViewControllerDelegate {
     }
     
     func capture(_ capture: CaptureViewController, didOutput mediaURL: URL, type: MediaType) {
-        captureDelegate?.imageCapture(self, didFinishCapturing: mediaURL, type: type)
+        let result = CaptureResult(mediaURL: mediaURL, type: type)
+        captureDelegate?.imageCapture(self, didFinishCapturing: result)
     }
 }
 
@@ -91,6 +92,7 @@ extension ImageCaptureController: PadCaptureViewControllerDelegate {
     }
     
     func capture(_ capture: PadCaptureViewController, didOutput mediaURL: URL, type: MediaType) {
-        captureDelegate?.imageCapture(self, didFinishCapturing: mediaURL, type: type)
+        let result = CaptureResult(mediaURL: mediaURL, type: type)
+        captureDelegate?.imageCapture(self, didFinishCapturing: result)
     }
 }

--- a/Sources/AnyImageKit/Editor/Controller/ImageEditorController.swift
+++ b/Sources/AnyImageKit/Editor/Controller/ImageEditorController.swift
@@ -12,7 +12,7 @@ import SnapKit
 public protocol ImageEditorControllerDelegate: class {
     
     func imageEditorDidCancel(_ editor: ImageEditorController)
-    func imageEditor(_ editor: ImageEditorController, didFinishEditing mediaURL: URL, type: MediaType, isEdited: Bool)
+    func imageEditor(_ editor: ImageEditorController, didFinishEditing result: EditorResult)
 }
 
 extension ImageEditorControllerDelegate {
@@ -156,10 +156,11 @@ extension ImageEditorController: PhotoEditorControllerDelegate {
     }
     
     func photoEditor(_ editor: PhotoEditorController, didFinishEditing photo: UIImage, isEdited: Bool) {
-        let result = output(photo: photo, fileType: .jpeg)
-        switch result {
+        let outputResult = output(photo: photo, fileType: .jpeg)
+        switch outputResult {
         case .success(let url):
-            editorDelegate?.imageEditor(self, didFinishEditing: url, type: .photo, isEdited: isEdited)
+            let result = EditorResult(mediaURL: url, type: .photo, isEdited: isEdited)
+            editorDelegate?.imageEditor(self, didFinishEditing: result)
         case .failure(let error):
             _print(error.localizedDescription)
         }
@@ -174,6 +175,7 @@ extension ImageEditorController: VideoEditorControllerDelegate {
     }
     
     func videoEditor(_ editor: VideoEditorController, didFinishEditing video: URL, isEdited: Bool) {
-        editorDelegate?.imageEditor(self, didFinishEditing: video, type: .video, isEdited: isEditing)
+        let result = EditorResult(mediaURL: video, type: .video, isEdited: isEdited)
+        editorDelegate?.imageEditor(self, didFinishEditing: result)
     }
 }

--- a/Sources/AnyImageKit/Editor/EditorResult.swift
+++ b/Sources/AnyImageKit/Editor/EditorResult.swift
@@ -1,0 +1,22 @@
+//
+//  EditorResult.swift
+//  AnyImageKit
+//
+//  Created by 刘栋 on 2020/9/28.
+//  Copyright © 2020 AnyImageProject.org. All rights reserved.
+//
+
+import Foundation
+
+public struct EditorResult: Equatable {
+    
+    public let mediaURL: URL
+    public let type: MediaType
+    public let isEdited: Bool
+    
+    init(mediaURL: URL, type: MediaType, isEdited: Bool) {
+        self.mediaURL = mediaURL
+        self.type = type
+        self.isEdited = isEdited
+    }
+}

--- a/Sources/AnyImageKit/Picker/Controller/AssetPickerViewController+Capture.swift
+++ b/Sources/AnyImageKit/Picker/Controller/AssetPickerViewController+Capture.swift
@@ -76,12 +76,12 @@ extension AssetPickerViewController {
 // MARK: - ImageCaptureControllerDelegate
 extension AssetPickerViewController: ImageCaptureControllerDelegate {
     
-    func imageCapture(_ capture: ImageCaptureController, didFinishCapturing mediaURL: URL, type: MediaType) {
+    func imageCapture(_ capture: ImageCaptureController, didFinishCapturing result: CaptureResult) {
         capture.dismiss(animated: true, completion: nil)
         showWaitHUD()
-        switch type {
+        switch result.type {
         case .photo:
-            manager.savePhoto(url: mediaURL) { [weak self] (result) in
+            manager.savePhoto(url: result.mediaURL) { [weak self] (result) in
                 switch result {
                 case .success(let asset):
                     self?.addPHAsset(asset)
@@ -91,7 +91,7 @@ extension AssetPickerViewController: ImageCaptureControllerDelegate {
                 hideHUD()
             }
         case .video:
-            manager.saveVideo(url: mediaURL) { [weak self] (result) in
+            manager.saveVideo(url: result.mediaURL) { [weak self] (result) in
                 switch result {
                 case .success(let asset):
                     self?.addPHAsset(asset)

--- a/Sources/AnyImageKit/Picker/Controller/ImagePickerController.swift
+++ b/Sources/AnyImageKit/Picker/Controller/ImagePickerController.swift
@@ -12,7 +12,7 @@ import SnapKit
 public protocol ImagePickerControllerDelegate: class {
     
     func imagePickerDidCancel(_ picker: ImagePickerController)
-    func imagePicker(_ picker: ImagePickerController, didFinishPicking assets: [Asset], useOriginalImage: Bool)
+    func imagePicker(_ picker: ImagePickerController, didFinishPicking result: PickerResult)
 }
 
 extension ImagePickerControllerDelegate {
@@ -157,7 +157,8 @@ extension ImagePickerController {
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
                 hideHUD()
-                self.pickerDelegate?.imagePicker(self, didFinishPicking: self.manager.selectedAssets, useOriginalImage: self.manager.useOriginalImage)
+                let result = PickerResult(assets: self.manager.selectedAssets, useOriginalImage: self.manager.useOriginalImage)
+                self.pickerDelegate?.imagePicker(self, didFinishPicking: result)
             }
         }
     }

--- a/Sources/AnyImageKit/Picker/Controller/PhotoPreviewController+Editor.swift
+++ b/Sources/AnyImageKit/Picker/Controller/PhotoPreviewController+Editor.swift
@@ -94,14 +94,14 @@ extension PhotoPreviewController: ImageEditorControllerDelegate {
         }
     }
     
-    func imageEditor(_ editor: ImageEditorController, didFinishEditing mediaURL: URL, type: MediaType, isEdited: Bool) {
+    func imageEditor(_ editor: ImageEditorController, didFinishEditing result: EditorResult) {
         defer { editor.dismiss(animated: false, completion: nil) }
-        guard type == .photo else { return }
-        guard let photoData = try? Data(contentsOf: mediaURL) else { return }
+        guard result.type == .photo else { return }
+        guard let photoData = try? Data(contentsOf: result.mediaURL) else { return }
         guard let photo = UIImage(data: photoData) else { return }
         guard let data = dataSource?.previewController(self, assetOfIndex: currentIndex) else { return }
         guard let cell = collectionView.cellForItem(at: IndexPath(item: currentIndex, section: 0)) as? PhotoPreviewCell else { return }
-        data.asset._images[.edited] = isEdited ? photo : nil
+        data.asset._images[.edited] = result.isEdited ? photo : nil
         cell.setImage(photo)
         
         // 选择当前照片

--- a/Sources/AnyImageKit/Picker/PickerResult.swift
+++ b/Sources/AnyImageKit/Picker/PickerResult.swift
@@ -1,0 +1,20 @@
+//
+//  PickerResult.swift
+//  AnyImageKit
+//
+//  Created by 刘栋 on 2020/9/28.
+//  Copyright © 2020 AnyImageProject.org. All rights reserved.
+//
+
+import Foundation
+
+public struct PickerResult: Equatable {
+    
+    public let assets: [Asset]
+    public let useOriginalImage: Bool
+    
+    init(assets: [Asset], useOriginalImage: Bool) {
+        self.assets = assets
+        self.useOriginalImage = useOriginalImage
+    }
+}


### PR DESCRIPTION
使用 `PickerResult`, `EditorResult`, `CaptureResult` 代替原代理回调中的分散对象，为未来的 ABI 稳定作准备