### PR TITLE
feat: add init func without delegate, now you can set delegate later

### DIFF
--- a/Sources/AnyImageKit/Capture/Controller/ImageCaptureController.swift
+++ b/Sources/AnyImageKit/Capture/Controller/ImageCaptureController.swift
@@ -24,14 +24,13 @@ extension ImageCaptureControllerDelegate {
 
 open class ImageCaptureController: AnyImageNavigationController {
     
-    open private(set) weak var captureDelegate: ImageCaptureControllerDelegate?
+    open weak var captureDelegate: ImageCaptureControllerDelegate?
     
-    /// Init capture controller
+    /// Init Capture Controller
     /// - Note: iPadOS will use `UIImagePickerController` instead.
-    public required init(options: CaptureOptionsInfo, delegate: ImageCaptureControllerDelegate) {
+    public required init(options: CaptureOptionsInfo) {
         enableDebugLog = options.enableDebugLog
         super.init(nibName: nil, bundle: nil)
-        self.captureDelegate = delegate
         
         if UIDevice.current.userInterfaceIdiom == .pad {
             let rootViewController = PadCaptureViewController(options: options)
@@ -42,6 +41,13 @@ open class ImageCaptureController: AnyImageNavigationController {
             rootViewController.delegate = self
             self.viewControllers = [rootViewController]
         }
+    }
+    
+    /// Init Capture Controller
+    /// - Note: iPadOS will use `UIImagePickerController` instead.
+    public convenience init(options: CaptureOptionsInfo, delegate: ImageCaptureControllerDelegate) {
+        self.init(options: options)
+        self.captureDelegate = delegate
     }
     
     @available(*, deprecated, message: "init(coder:) has not been implemented")

--- a/Sources/AnyImageKit/Editor/Controller/ImageEditorController.swift
+++ b/Sources/AnyImageKit/Editor/Controller/ImageEditorController.swift
@@ -24,28 +24,38 @@ extension ImageEditorControllerDelegate {
 
 open class ImageEditorController: AnyImageNavigationController {
     
-    public private(set) weak var editorDelegate: ImageEditorControllerDelegate?
+    open weak var editorDelegate: ImageEditorControllerDelegate?
     
     private var containerSize: CGSize = .zero
     
     /// Init Photo Editor
-    public required init(photo resource: EditorPhotoResource, options: EditorPhotoOptionsInfo, delegate: ImageEditorControllerDelegate) {
+    public required init(photo resource: EditorPhotoResource, options: EditorPhotoOptionsInfo) {
         enableDebugLog = options.enableDebugLog
         super.init(nibName: nil, bundle: nil)
         let checkedOptions = check(resource: resource, options: options)
-        self.editorDelegate = delegate
         let rootViewController = PhotoEditorController(photo: resource, options: checkedOptions, delegate: self)
         self.viewControllers = [rootViewController]
     }
     
+    /// Init Photo Editor
+    public convenience init(photo resource: EditorPhotoResource, options: EditorPhotoOptionsInfo, delegate: ImageEditorControllerDelegate) {
+        self.init(photo: resource, options: options)
+        self.editorDelegate = delegate
+    }
+    
     /// Init Video Editor
-    public required init(video resource: EditorVideoResource, placeholderImage: UIImage?, options: EditorVideoOptionsInfo, delegate: ImageEditorControllerDelegate) {
+    public required init(video resource: EditorVideoResource, placeholderImage: UIImage?, options: EditorVideoOptionsInfo) {
         enableDebugLog = options.enableDebugLog
         super.init(nibName: nil, bundle: nil)
         let checkedOptions = check(resource: resource, options: options)
-        self.editorDelegate = delegate
         let rootViewController = VideoEditorController(resource: resource, placeholderImage: placeholderImage, options: checkedOptions, delegate: self)
         self.viewControllers = [rootViewController]
+    }
+    
+    /// Init Video Editor
+    public convenience init(video resource: EditorVideoResource, placeholderImage: UIImage?, options: EditorVideoOptionsInfo, delegate: ImageEditorControllerDelegate) {
+        self.init(video: resource, placeholderImage: placeholderImage, options: options)
+        self.editorDelegate = delegate
     }
     
     @available(*, deprecated, message: "init(coder:) has not been implemented")
@@ -53,13 +63,13 @@ open class ImageEditorController: AnyImageNavigationController {
         fatalError("init(coder:) has not been implemented")
     }
     
+    deinit {
+        removeNotifications()
+    }
+    
     open override func viewDidLoad() {
         super.viewDidLoad()
         addNotification()
-    }
-    
-    deinit {
-        removeNotifications()
     }
     
     open override func viewDidLayoutSubviews() {

--- a/Sources/AnyImageKit/Picker/Controller/ImagePickerController.swift
+++ b/Sources/AnyImageKit/Picker/Controller/ImagePickerController.swift
@@ -24,7 +24,7 @@ extension ImagePickerControllerDelegate {
 
 open class ImagePickerController: AnyImageNavigationController {
     
-    public private(set) weak var pickerDelegate: ImagePickerControllerDelegate?
+    open weak var pickerDelegate: ImagePickerControllerDelegate?
     
     private var containerSize: CGSize = .zero
     private var hiddenStatusBar: Bool = false
@@ -33,7 +33,7 @@ open class ImagePickerController: AnyImageNavigationController {
     
     private let manager: PickerManager = .init()
     
-    public required init(options: PickerOptionsInfo, delegate: ImagePickerControllerDelegate) {
+    public required init(options: PickerOptionsInfo) {
         enableDebugLog = options.enableDebugLog
         // Note:
         // Can't use `init(rootViewController:)` cause it will also call `init(nibName:,bundle:)` and reset `manager` even it's declaration by `let`
@@ -41,7 +41,6 @@ open class ImagePickerController: AnyImageNavigationController {
         let newOptions = check(options: options)
         self.addNotifications()
         self.manager.options = newOptions
-        self.pickerDelegate = delegate
         
         let rootViewController = AssetPickerViewController(manager: manager)
         rootViewController.delegate = self
@@ -53,6 +52,11 @@ open class ImagePickerController: AnyImageNavigationController {
         #if ANYIMAGEKIT_ENABLE_EDITOR
         ImageEditorCache.clearDiskCache()
         #endif
+    }
+    
+    public convenience init(options: PickerOptionsInfo, delegate: ImagePickerControllerDelegate) {
+        self.init(options: options)
+        self.pickerDelegate = delegate
     }
     
     @available(*, deprecated, message: "init(coder:) has not been implemented")


### PR DESCRIPTION
新功能：
- 现在 `ImagePickerController`, `ImageEditorController`, `ImageCaptureController` 的默认初始化方法不再强制要求对应的 delegate，并开放对应的 delegate，你可以在晚一些的时候再设置，方便需要子类化的情况下，将代理设置为自己。
- 并同时新增对应的 convenience 初始化方法，保持原来的 API 稳定