### PR TITLE
fix: photolibrarydidchange called multiple times

### DIFF
--- a/Sources/AnyImageKit/Core/Controller/AnyImageViewController.swift
+++ b/Sources/AnyImageKit/Core/Controller/AnyImageViewController.swift
@@ -31,7 +31,7 @@ class AnyImageViewController: UIViewController {
    
     override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
         setTrackObserverOrDelegate(viewControllerToPresent)
-        super.present(viewControllerToPresent, animated: true, completion: completion)
+        super.present(viewControllerToPresent, animated: flag, completion: completion)
     }
 }
 

--- a/Sources/AnyImageKit/Picker/Controller/AssetPickerViewController.swift
+++ b/Sources/AnyImageKit/Picker/Controller/AssetPickerViewController.swift
@@ -115,16 +115,12 @@ final class AssetPickerViewController: AnyImageViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        if #available(iOS 14.0, *) {
-            PHPhotoLibrary.shared().register(self)
-        }
+        PHPhotoLibrary.shared().register(self)
     }
     
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        if #available(iOS 14.0, *) {
-            PHPhotoLibrary.shared().unregisterChangeObserver(self)
-        }
+        PHPhotoLibrary.shared().unregisterChangeObserver(self)
     }
     
     override func viewDidLayoutSubviews() {

--- a/Sources/AnyImageKit/Picker/Controller/AssetPickerViewController.swift
+++ b/Sources/AnyImageKit/Picker/Controller/AssetPickerViewController.swift
@@ -96,6 +96,11 @@ final class AssetPickerViewController: AnyImageViewController {
     init(manager: PickerManager) {
         self.manager = manager
         super.init(nibName: nil, bundle: nil)
+        PHPhotoLibrary.shared().register(self)
+    }
+    
+    deinit {
+        PHPhotoLibrary.shared().unregisterChangeObserver(self)
     }
     
     required init?(coder: NSCoder) {
@@ -111,16 +116,6 @@ final class AssetPickerViewController: AnyImageViewController {
             setupDataSource()
         }
         checkPermission()
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        PHPhotoLibrary.shared().register(self)
-    }
-    
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        PHPhotoLibrary.shared().unregisterChangeObserver(self)
     }
     
     override func viewDidLayoutSubviews() {

--- a/Sources/AnyImageKit/Picker/Controller/AssetPickerViewController.swift
+++ b/Sources/AnyImageKit/Picker/Controller/AssetPickerViewController.swift
@@ -200,7 +200,7 @@ extension AssetPickerViewController {
     private func setAlbum(_ album: Album) {
         guard self.album != album else { return }
         self.album = album
-        titleView.setTitle(album.name)
+        titleView.setTitle(album.title)
         manager.removeAllSelectedAsset()
         manager.cancelAllFetch()
         toolBar.setEnable(false)

--- a/Sources/AnyImageKit/Picker/Controller/AssetPickerViewController.swift
+++ b/Sources/AnyImageKit/Picker/Controller/AssetPickerViewController.swift
@@ -241,6 +241,7 @@ extension AssetPickerViewController {
     }
     
     private func reloadAlbum(_ album: Album) {
+        guard !stopReloadAlbum else { return }
         manager.fetchAlbum(album) { [weak self] newAlbum in
             guard let self = self else { return }
             self.updateAlbum(newAlbum)
@@ -422,12 +423,13 @@ extension AssetPickerViewController {
 extension AssetPickerViewController: PHPhotoLibraryChangeObserver {
     
     func photoLibraryDidChange(_ changeInstance: PHChange) {
-        guard
-            let album = album,
-            let changeDetails = changeInstance.changeDetails(for: album.fetchResult),
-            changeDetails.hasIncrementalChanges
-        else {
+        guard let album = album, let changeDetails = changeInstance.changeDetails(for: album.fetchResult) else { return }
+        
+        if #available(iOS 14.0, *), Permission.photos.status == .limited {
+            reloadAlbum(album)
             return
+        } else {
+            guard changeDetails.hasIncrementalChanges else { return }
         }
         
         // Check Insert

--- a/Sources/AnyImageKit/Picker/Controller/AssetPickerViewController.swift
+++ b/Sources/AnyImageKit/Picker/Controller/AssetPickerViewController.swift
@@ -31,8 +31,7 @@ final class AssetPickerViewController: AnyImageViewController {
     
     @available(iOS 14.0, *)
     private lazy var dataSource = UICollectionViewDiffableDataSource<Section, Asset>()
-    @available(iOS 14.0, *)
-    private lazy var lastPhotoLibraryUpdateTime: TimeInterval = 0
+    
     private lazy var stopReloadAlbum: Bool = false
     
     private lazy var titleView: PickerArrowButton = {

--- a/Sources/AnyImageKit/Picker/Model/Album.swift
+++ b/Sources/AnyImageKit/Picker/Model/Album.swift
@@ -11,20 +11,23 @@ import Photos
 
 class Album: Equatable {
     
-    let id: String
+    let fetchResult: PHFetchResult<PHAsset>
+    
+    let identifier: String
     let name: String
     let isCameraRoll: Bool
     private(set) var assets: [Asset] = []
     
-    init(result: PHFetchResult<PHAsset>, id: String, name: String?, isCameraRoll: Bool, selectOptions: PickerSelectOption) {
-        self.id = id
+    init(fetchResult: PHFetchResult<PHAsset>, identifier: String, name: String?, isCameraRoll: Bool, selectOptions: PickerSelectOption) {
+        self.fetchResult = fetchResult
+        self.identifier = identifier
         self.name = name ?? ""
         self.isCameraRoll = isCameraRoll
-        fetchAssets(result: result, selectOptions: selectOptions)
+        fetchAssets(result: fetchResult, selectOptions: selectOptions)
     }
     
     static func == (lhs: Album, rhs: Album) -> Bool {
-        return lhs.id == rhs.id
+        return lhs.identifier == rhs.identifier
     }
 }
 

--- a/Sources/AnyImageKit/Picker/Model/Album.swift
+++ b/Sources/AnyImageKit/Picker/Model/Album.swift
@@ -14,14 +14,14 @@ class Album: Equatable {
     let fetchResult: PHFetchResult<PHAsset>
     
     let identifier: String
-    let name: String
+    let title: String
     let isCameraRoll: Bool
     private(set) var assets: [Asset] = []
     
-    init(fetchResult: PHFetchResult<PHAsset>, identifier: String, name: String?, isCameraRoll: Bool, selectOptions: PickerSelectOption) {
+    init(fetchResult: PHFetchResult<PHAsset>, identifier: String, title: String?, isCameraRoll: Bool, selectOptions: PickerSelectOption) {
         self.fetchResult = fetchResult
         self.identifier = identifier
-        self.name = name ?? ""
+        self.title = title ?? ""
         self.isCameraRoll = isCameraRoll
         fetchAssets(result: fetchResult, selectOptions: selectOptions)
     }
@@ -114,6 +114,6 @@ extension Album {
 extension Album: CustomStringConvertible {
     
     var description: String {
-        return "Album<\(name)>"
+        return "Album<\(title)>"
     }
 }

--- a/Sources/AnyImageKit/Picker/Util/PickerManager+Album.swift
+++ b/Sources/AnyImageKit/Picker/Util/PickerManager+Album.swift
@@ -33,9 +33,37 @@ extension PickerManager {
             if assetCollection.estimatedAssetCount <= 0 { continue }
             if assetCollection.isCameraRoll {
                 let assetsfetchResult = PHAsset.fetchAssets(in: assetCollection, options: fetchOptions)
-                let result = Album(result: assetsfetchResult, id: assetCollection.localIdentifier, name: assetCollection.localizedTitle, isCameraRoll: true, selectOptions: options.selectOptions)
+                let result = Album(fetchResult: assetsfetchResult,
+                                   identifier: assetCollection.localIdentifier,
+                                   name: assetCollection.localizedTitle,
+                                   isCameraRoll: true,
+                                   selectOptions: options.selectOptions)
                 completion(result)
                 return
+            }
+        }
+    }
+    
+    func fetchAlbum(_ album: Album, completion: @escaping (Album) -> Void) {
+        workQueue.async { [weak self] in
+            guard let self = self else { return }
+            let fetchOptions = self.createFetchOptions()
+            let assetCollectionsFetchResult = PHAssetCollection.fetchAssetCollections(with: .smartAlbum, subtype: .albumRegular, options: nil)
+            let assetCollections = assetCollectionsFetchResult.objects()
+            for assetCollection in assetCollections {
+                if assetCollection.estimatedAssetCount <= 0 { continue }
+                if assetCollection.localIdentifier == album.identifier {
+                    let assetsfetchResult = PHAsset.fetchAssets(in: assetCollection, options: fetchOptions)
+                    let result = Album(fetchResult: assetsfetchResult,
+                                       identifier: assetCollection.localIdentifier,
+                                       name: assetCollection.localizedTitle,
+                                       isCameraRoll: assetCollection.isCameraRoll,
+                                       selectOptions: self.options.selectOptions)
+                    DispatchQueue.main.async {
+                        completion(result)
+                        return
+                    }
+                }
             }
         }
     }
@@ -54,20 +82,25 @@ extension PickerManager {
                     
                     if assetCollection.isAllHidden { continue }
                     if assetCollection.isRecentlyDeleted  { continue }
+                    if results.contains(where: { assetCollection.localIdentifier == $0.identifier }) { continue }
                     
                     let assetFetchResult = PHAsset.fetchAssets(in: assetCollection, options: options)
                     if assetFetchResult.count <= 0 && !isCameraRoll { continue }
                     
                     if isCameraRoll {
-                        if !results.contains(where: { $0.id == assetCollection.localIdentifier }) {
-                            let album = Album(result: assetFetchResult, id: assetCollection.localIdentifier, name: assetCollection.localizedTitle, isCameraRoll: true, selectOptions: self.options.selectOptions)
-                            results.insert(album, at: 0)
-                        }
+                        let result = Album(fetchResult: assetFetchResult,
+                                           identifier: assetCollection.localIdentifier,
+                                           name: assetCollection.localizedTitle,
+                                           isCameraRoll: true,
+                                           selectOptions: self.options.selectOptions)
+                        results.insert(result, at: 0)
                     } else {
-                        if !results.contains(where: { $0.id == assetCollection.localIdentifier }) {
-                            let album = Album(result: assetFetchResult, id: assetCollection.localIdentifier, name: assetCollection.localizedTitle, isCameraRoll: false, selectOptions: self.options.selectOptions)
-                            results.append(album)
-                        }
+                        let result = Album(fetchResult: assetFetchResult,
+                                           identifier: assetCollection.localIdentifier,
+                                           name: assetCollection.localizedTitle,
+                                           isCameraRoll: false,
+                                           selectOptions: self.options.selectOptions)
+                        results.append(result)
                     }
                 }
             }

--- a/Sources/AnyImageKit/Picker/Util/PickerManager+Album.swift
+++ b/Sources/AnyImageKit/Picker/Util/PickerManager+Album.swift
@@ -35,7 +35,7 @@ extension PickerManager {
                 let assetsfetchResult = PHAsset.fetchAssets(in: assetCollection, options: fetchOptions)
                 let result = Album(fetchResult: assetsfetchResult,
                                    identifier: assetCollection.localIdentifier,
-                                   name: assetCollection.localizedTitle,
+                                   title: assetCollection.localizedTitle,
                                    isCameraRoll: true,
                                    selectOptions: options.selectOptions)
                 completion(result)
@@ -56,7 +56,7 @@ extension PickerManager {
                     let assetsfetchResult = PHAsset.fetchAssets(in: assetCollection, options: fetchOptions)
                     let result = Album(fetchResult: assetsfetchResult,
                                        identifier: assetCollection.localIdentifier,
-                                       name: assetCollection.localizedTitle,
+                                       title: assetCollection.localizedTitle,
                                        isCameraRoll: assetCollection.isCameraRoll,
                                        selectOptions: self.options.selectOptions)
                     DispatchQueue.main.async {
@@ -90,14 +90,14 @@ extension PickerManager {
                     if isCameraRoll {
                         let result = Album(fetchResult: assetFetchResult,
                                            identifier: assetCollection.localIdentifier,
-                                           name: assetCollection.localizedTitle,
+                                           title: assetCollection.localizedTitle,
                                            isCameraRoll: true,
                                            selectOptions: self.options.selectOptions)
                         results.insert(result, at: 0)
                     } else {
                         let result = Album(fetchResult: assetFetchResult,
                                            identifier: assetCollection.localIdentifier,
-                                           name: assetCollection.localizedTitle,
+                                           title: assetCollection.localizedTitle,
                                            isCameraRoll: false,
                                            selectOptions: self.options.selectOptions)
                         results.append(result)

--- a/Sources/AnyImageKit/Picker/View/Cell/AlbumCell.swift
+++ b/Sources/AnyImageKit/Picker/View/Cell/AlbumCell.swift
@@ -86,7 +86,7 @@ extension AlbumCell {
     
     func setContent(_ album: Album, manager: PickerManager) {
         updateTheme(manager.options.theme)
-        titleLabel.text = album.name
+        titleLabel.text = album.title
         subTitleLabel.text = "(\(album.count))"
         manager.requestPhoto(for: album) { [weak self] result in
             guard let self = self else { return }


### PR DESCRIPTION
- 修复 PHPhotoLibraryChangeObserver 可能多次调用导致页面多次刷新的问题，现在所有版本的 iOS 都能监控相册变化，并自动刷新当前相册