### PR TITLE
feat: same tabbar color

### DIFF
--- a/Sources/AnyImageKit/Picker/Controller/AssetPickerViewController.swift
+++ b/Sources/AnyImageKit/Picker/Controller/AssetPickerViewController.swift
@@ -352,7 +352,7 @@ extension AssetPickerViewController {
         controller.albums = albums
         controller.delegate = self
         let presentationController = MenuDropDownPresentationController(presentedViewController: controller, presenting: self)
-        let isFullScreen = ScreenHelper.mainBounds.height == view.frame.height
+        let isFullScreen = ScreenHelper.mainBounds.height == navigationController?.view.frame.height ?? view.frame.height
         presentationController.isFullScreen = isFullScreen
         presentationController.cornerRadius = 8
         presentationController.corners = [.bottomLeft, .bottomRight]

--- a/Sources/AnyImageKit/Picker/Controller/ImagePickerController.swift
+++ b/Sources/AnyImageKit/Picker/Controller/ImagePickerController.swift
@@ -47,7 +47,10 @@ open class ImagePickerController: AnyImageNavigationController {
         rootViewController.trackObserver = self
         self.viewControllers = [rootViewController]
         
-        navigationBar.barTintColor = newOptions.theme.backgroundColor
+        navigationBar.isTranslucent = false
+        navigationBar.shadowImage = UIImage()
+        navigationBar.setBackgroundImage(UIImage(), for: .default)
+        navigationBar.barTintColor = newOptions.theme.toolBarColor
         navigationBar.tintColor = newOptions.theme.textColor
         
         #if ANYIMAGEKIT_ENABLE_EDITOR

--- a/Sources/AnyImageKit/Picker/View/PickerToolBar.swift
+++ b/Sources/AnyImageKit/Picker/View/PickerToolBar.swift
@@ -12,13 +12,6 @@ final class PickerToolBar: UIView {
     
     private(set) lazy var contentView = UIView(frame: .zero)
     
-    private lazy var backgroundView: UIVisualEffectView = {
-        let effect = UIBlurEffect(style: .light)
-        let view = UIVisualEffectView(effect: effect)
-        view.contentView.backgroundColor = options.theme.backgroundColor.withAlphaComponent(0.7)
-        return view
-    }()
-    
     private(set) lazy var leftButton: UIButton = {
         let view = UIButton(type: .custom)
         view.backgroundColor = UIColor.clear
@@ -75,20 +68,16 @@ final class PickerToolBar: UIView {
     }
     
     private func setupView() {
+        backgroundColor = options.theme.toolBarColor
         switch style {
         case .picker:
-            addSubview(backgroundView)
             addSubview(permissionLimitedView)
-            backgroundView.snp.makeConstraints { maker in
-                maker.edges.equalToSuperview()
-            }
             permissionLimitedView.snp.makeConstraints { maker in
                 maker.top.left.right.equalToSuperview()
                 maker.height.equalTo(limitedViewHeight)
             }
             leftButton.setTitle(BundleHelper.pickerLocalizedString(key: "Preview"), for: .normal)
         case .preview:
-            backgroundColor = options.theme.toolBarColor
             leftButton.setTitle(BundleHelper.pickerLocalizedString(key: "Edit"), for: .normal)
         }
         

--- a/Sources/AnyImageKit/Picker/View/PickerToolBar.swift
+++ b/Sources/AnyImageKit/Picker/View/PickerToolBar.swift
@@ -50,7 +50,7 @@ final class PickerToolBar: UIView {
         return view
     }()
     
-    let limitedViewHeight: CGFloat = 64
+    let limitedViewHeight: CGFloat = 56
     let toolBarHeight: CGFloat = 56
     
     private let style: Style


### PR DESCRIPTION
- feat: 将 asset picker 和 preview 的导航栏/tabbar 颜色设为一致，移除 asset picker 中的毛玻璃效果	
- feat: limited 提示框的高度改为 56
