### PR TITLE
fix: ios11_black_focusrectview

### DIFF
--- a/Sources/AnyImageKit/Capture/View/CaptureFocusView.swift
+++ b/Sources/AnyImageKit/Capture/View/CaptureFocusView.swift
@@ -238,6 +238,7 @@ private final class CaptureFocusRectView: UIView {
     }
     
     private func setupView() {
+        backgroundColor = .clear
         layer.addSublayer(rectLayer)
     }
     


### PR DESCRIPTION
- 修复 iOS 11 上对焦框变黑的问题，猜测 iOS 11 以前 UIView 的默认颜色为 .black