### PR TITLE
fix: remove language bundle

### DIFF
--- a/Example/Resources/en.lproj/Localizable.strings
+++ b/Example/Resources/en.lproj/Localizable.strings
@@ -7,7 +7,7 @@
 */
 
 // Picker
-"OpenPicker" = "Open picker";
+"OpenPicker" = "Open Picker";
 "Theme" = "Theme";
 "SelectLimit" = "Select Limit";
 "ColumnNumber" = "Column Number";
@@ -21,7 +21,7 @@
 "FullScreen" = "Full Screen";
 
 // Editor
-"OpenEditor" = "Open editor";
+"OpenEditor" = "Open Editor";
 "EditOptions" = "Edit Options";
 "PenWidth" = "Pen Width";
 "MosaicOptions" = "Mosaic Options";
@@ -30,7 +30,7 @@
 "CropOptions" = "Crop Options";
 
 // Capture
-"OpenCamera" = "Open camera";
+"OpenCamera" = "Open Camera";
 "MediaOptions" = "Media Options";
 "PreferredPresets" = "Preferred Presets";
 "PhotoAspectRatio" = "Photo Aspect Ratio";

--- a/Sources/AnyImageKit/Core/Util/Common/BundleHelper.swift
+++ b/Sources/AnyImageKit/Core/Util/Common/BundleHelper.swift
@@ -72,11 +72,18 @@ extension BundleHelper {
 extension BundleHelper {
     
     static func localizedString(key: String, value: String?, table: String) -> String {
-        if let result = languageBundle?.localizedString(forKey: key, value: value, table: table), result != key {
-            return result
-        } else if table != "Core", let result = languageBundle?.localizedString(forKey: key, value: value, table: "Core"), result != key {
-            return result
+        let currentTableResult = Bundle.current.localizedString(forKey: key, value: value, table: table)
+        if currentTableResult != key {
+            return currentTableResult
         }
+        
+        if table != "Core" {
+            let coreTableResult = Bundle.current.localizedString(forKey: key, value: value, table: "Core")
+            if coreTableResult != key {
+                return coreTableResult
+            }
+        }
+        
         return Bundle.main.localizedString(forKey: key, value: value, table: nil)
     }
     

--- a/Sources/AnyImageKit/Core/Util/Common/BundleHelper.swift
+++ b/Sources/AnyImageKit/Core/Util/Common/BundleHelper.swift
@@ -10,27 +10,6 @@ import UIKit
 
 struct BundleHelper {
     
-    static private var _languageBundle: Bundle?
-    
-    static var languageBundle: Bundle? {
-        if _languageBundle == nil {
-            var language = Locale.preferredLanguages.first ?? "en"
-            if language.hasPrefix("zh") {
-                if language.contains("Hans") {
-                    language = "zh-Hans"
-                } else {
-                    language = "zh-Hant"
-                }
-            }
-            _languageBundle = Bundle(path: Bundle.current.path(forResource: language, ofType: "lproj") ?? "")
-        }
-        return _languageBundle
-    }
-}
-
-// MARK: - Info
-extension BundleHelper {
-    
     static var appName: String {
         if let info = Bundle.main.localizedInfoDictionary {
             if let appName = info["CFBundleDisplayName"] as? String { return appName }

--- a/Sources/AnyImageKit/Picker/View/Kit/LivePhotoTipView.swift
+++ b/Sources/AnyImageKit/Picker/View/Kit/LivePhotoTipView.swift
@@ -18,7 +18,7 @@ final class LivePhotoTipView: UIView {
     private lazy var label: UILabel = {
         let view = UILabel(frame: .zero)
         view.text = BundleHelper.pickerLocalizedString(key: "Live photo")
-        view.font = UIFont.systemFont(ofSize: 12)
+        view.font = UIFont.systemFont(ofSize: 13)
         return view
     }()
     

--- a/Sources/AnyImageKit/Resources/Picker/en.lproj/Picker.strings
+++ b/Sources/AnyImageKit/Resources/Picker/en.lproj/Picker.strings
@@ -8,7 +8,7 @@
 
 "Photo" = "Photo";
 "Video" = "Video";
-"Live photo" = "Live photo";
+"Live photo" = "LIVE";
 "Original image" = "Original image";
 "Select photo" = "Select photo";
 "Unselect photo" = "Unselect photo";


### PR DESCRIPTION
- 当前的 language bundle 设计在英文语境下实际是不可用的
- 测试了 iOS 11/13/14 的设备，`Locale.preferredLanguages.first` 均返回 *en-CN*，但实际上并没有 en-CN 的 lproj 文件，导致 languageBundle 直接为 nil，使得 localizedString 相关方法直接返回 key，由于当前英文语境下的 key 与 value 一致，所以之前一直未发现该问题
- 尝试将 "Live photo" 提示改为系统一致的 "LIVE" 时发现该问题
- 本质上 languageBundle 的设计是为了应用语言与系统语言可以不同配置而设计的，当前其实我们也不支持与系统不一致，所以可以废弃该设计，直接使用 `Bundle.current` 代替
- 若要保留则需要和中文语境一样，自行配置各种语言对应的 lproj 文件的名称，考虑到不同系统适配，建议不要这样做