### PR TITLE
fix: preview video without progress

### DIFF
--- a/Example/Controller/PickerResultViewController.swift
+++ b/Example/Controller/PickerResultViewController.swift
@@ -76,9 +76,13 @@ extension PickerResultViewController: UICollectionViewDelegate {
         case .video:
             let alert = UIAlertController(title: "Processing", message: nil, preferredStyle: .alert)
             let options = VideoURLFetchOptions(fetchProgressHandler: { (progress, _, _, _) in
-                alert.message = "Fetching \(String(format: "%0.1f %", progress*100))"
+                DispatchQueue.main.async {
+                    alert.message = "Fetching \(String(format: "%0.1f %", progress*100))"
+                }
             }, exportPreset: .h264_1280x720) { progress in
-                alert.message = "Exporting \(String(format: "%0.1f %", progress*100))"
+                DispatchQueue.main.async {
+                    alert.message = "Exporting \(String(format: "%0.1f %", progress*100))"
+                }
             }
             present(alert, animated: true, completion: nil)
             asset.fetchVideoURL(options: options) { result, _ in

--- a/Sources/AnyImageKit/Core/Util/Export/ExportTool+Video.swift
+++ b/Sources/AnyImageKit/Core/Util/Export/ExportTool+Video.swift
@@ -45,10 +45,10 @@ extension ExportTool {
         requestOptions.deliveryMode = options.deliveryMode
         requestOptions.progressHandler = options.progressHandler
         
-        return PHImageManager.default().requestPlayerItem(forVideo: asset, options: requestOptions) { (playerItem, info) in
+        return PHImageManager.default().requestAVAsset(forVideo: asset, options: requestOptions) { (avAsset, _, info) in
             let requestID = (info?[PHImageResultRequestIDKey] as? PHImageRequestID) ?? 0
-            if let playerItem = playerItem {
-                completion(.success(.init(playerItem: playerItem)), requestID)
+            if let avAsset = avAsset {
+                completion(.success(.init(playerItem: AVPlayerItem(asset: avAsset))), requestID)
             } else {
                 completion(.failure(.invalidVideo), requestID)
             }

--- a/Sources/AnyImageKit/Core/Util/Export/ExportTool+VideoURL.swift
+++ b/Sources/AnyImageKit/Core/Util/Export/ExportTool+VideoURL.swift
@@ -23,7 +23,7 @@ public struct VideoURLFetchOptions {
     
     public init(isNetworkAccessAllowed: Bool = true,
                 version: PHVideoRequestOptionsVersion = .current,
-                deliveryMode: PHVideoRequestOptionsDeliveryMode = .automatic,
+                deliveryMode: PHVideoRequestOptionsDeliveryMode = .highQualityFormat,
                 fetchProgressHandler: PHAssetVideoProgressHandler? = nil,
                 preferredOutputPath: String? = nil,
                 exportPreset: VideoExportPreset = .h264_1280x720,


### PR DESCRIPTION
- 由于在 iOS 14 下 `PHImageManager.default().requestPlayerItem` 返回的 `AVPlayerItem` 如果存在于 iCloud 中，其引用的仍是远端地址，会造成显示的缓冲立刻就完成了，但实际播放时还需要缓冲很久，造成心理落差，影响用户体验，使用 `PHImageManager.default().requestAVAsset` 代替，强制提前完成缓冲