### PR TITLE
修复DESC排序时，获取图片错误的问题

### DIFF
--- a/Sources/AnyImageKit/Picker/Controller/AssetPickerViewController.swift
+++ b/Sources/AnyImageKit/Picker/Controller/AssetPickerViewController.swift
@@ -83,12 +83,16 @@ final class AssetPickerViewController: AnyImageViewController {
     }()
     
     private lazy var itemOffset: Int = {
+        #if ANYIMAGEKIT_ENABLE_CAPTURE
         switch manager.options.orderByDate {
         case .asc:
             return 0
         case .desc:
-            return 1
+            return manager.options.captureOptions.mediaOptions.isEmpty ? 0 : 1
         }
+        #else
+        return 0
+        #endif
     }()
     
     let manager: PickerManager


### PR DESCRIPTION
DESC 排序时，如果有相机，相机排在第一个位置，所以需要 offset。
但是 offset 没判断没有相机的情况，所以当 DESC 排序且没有相机的时候，就会导致数据出错。