### PR TITLE
Open editor after selection

### DIFF
--- a/AnyImageKit.xcodeproj/project.pbxproj
+++ b/AnyImageKit.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		71CBF1432519CC4B00F79D19 /* Core+UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71CBF1422519CC4B00F79D19 /* Core+UIView.swift */; };
 		71CBF1472519CF1400F79D19 /* EditorOptionsInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71CBF1462519CF1400F79D19 /* EditorOptionsInfo.swift */; };
 		71CBF1592519E5BF00F79D19 /* PermissionLimitedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71CBF1582519E5BF00F79D19 /* PermissionLimitedView.swift */; };
+		71D6BB2225930F320046B70C /* AssetPickerViewController+Editor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71D6BB2125930F320046B70C /* AssetPickerViewController+Editor.swift */; };
 		A005C309253D306C0021E323 /* AnyImagePage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A005C308253D306C0021E323 /* AnyImagePage.swift */; };
 		A005C30D253D33180021E323 /* AnyImageEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A005C30C253D33180021E323 /* AnyImageEvent.swift */; };
 		A00869BD233C987600237651 /* AssociatedObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00869BC233C987600237651 /* AssociatedObject.swift */; };
@@ -256,6 +257,7 @@
 		71CBF1422519CC4B00F79D19 /* Core+UIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Core+UIView.swift"; sourceTree = "<group>"; };
 		71CBF1462519CF1400F79D19 /* EditorOptionsInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorOptionsInfo.swift; sourceTree = "<group>"; };
 		71CBF1582519E5BF00F79D19 /* PermissionLimitedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionLimitedView.swift; sourceTree = "<group>"; };
+		71D6BB2125930F320046B70C /* AssetPickerViewController+Editor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AssetPickerViewController+Editor.swift"; sourceTree = "<group>"; };
 		A005C308253D306C0021E323 /* AnyImagePage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyImagePage.swift; sourceTree = "<group>"; };
 		A005C30C253D33180021E323 /* AnyImageEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyImageEvent.swift; sourceTree = "<group>"; };
 		A005F8E823973FC8006BE028 /* CaptureViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureViewController.swift; sourceTree = "<group>"; };
@@ -720,6 +722,7 @@
 				A0800410232F4EE4006B4711 /* ImagePickerController.swift */,
 				A0F4753F232F89C600BB117B /* AlbumPickerViewController.swift */,
 				A0800412232F5B44006B4711 /* AssetPickerViewController.swift */,
+				71D6BB2125930F320046B70C /* AssetPickerViewController+Editor.swift */,
 				A03806B323BF2DF2002873A9 /* AssetPickerViewController+Capture.swift */,
 				A56A3C7723306CB700EBFC48 /* PhotoPreviewController.swift */,
 				A5EFE3F8237D3E060071F39F /* PhotoPreviewController+Editor.swift */,
@@ -1429,6 +1432,7 @@
 				A07D8796233DA2B8000108C7 /* Picker+PHAsset.swift in Sources */,
 				A56A3C882330A44B00EBFC48 /* ScaleAnimator.swift in Sources */,
 				A5FA4AF5239F32220007C99B /* ColorButton.swift in Sources */,
+				71D6BB2225930F320046B70C /* AssetPickerViewController+Editor.swift in Sources */,
 				A54436F923AB193F003C65F9 /* VideoPreview.swift in Sources */,
 				A5347D2E23AA1EC000C93874 /* ExportTool+PhotoLive.swift in Sources */,
 				A0226A4023AB69F1000AFC87 /* Capture+AVCaptureDevice.swift in Sources */,

--- a/Documentation/Wiki/PICKER_GUIDE_CN.md
+++ b/Documentation/Wiki/PICKER_GUIDE_CN.md
@@ -4,6 +4,34 @@
 
 
 
+## 目录
+
+- [调用/回调说明](https://github.com/AnyImageProject/AnyImageKit/wiki/Picker%E4%BD%BF%E7%94%A8%E8%AF%B4%E6%98%8E#%E8%B0%83%E7%94%A8%E5%9B%9E%E8%B0%83%E8%AF%B4%E6%98%8E)
+- [配置项说明](https://github.com/AnyImageProject/AnyImageKit/wiki/Picker%E4%BD%BF%E7%94%A8%E8%AF%B4%E6%98%8E#%E9%85%8D%E7%BD%AE%E9%A1%B9%E8%AF%B4%E6%98%8E)
+  - [Theme](https://github.com/AnyImageProject/AnyImageKit/wiki/Picker%E4%BD%BF%E7%94%A8%E8%AF%B4%E6%98%8E#theme-pickertheme)
+  - [SelectLimit](https://github.com/AnyImageProject/AnyImageKit/wiki/Picker%E4%BD%BF%E7%94%A8%E8%AF%B4%E6%98%8E#selectlimit-int)
+  - [ColumnNumber](https://github.com/AnyImageProject/AnyImageKit/wiki/Picker%E4%BD%BF%E7%94%A8%E8%AF%B4%E6%98%8E#columnnumber-int)
+  - [AutoCalculateColumnNumber](https://github.com/AnyImageProject/AnyImageKit/wiki/Picker%E4%BD%BF%E7%94%A8%E8%AF%B4%E6%98%8E#autocalculatecolumnnumber-bool)
+  - [AllowUseOriginalImage](https://github.com/AnyImageProject/AnyImageKit/wiki/Picker%E4%BD%BF%E7%94%A8%E8%AF%B4%E6%98%8E#allowuseoriginalimage-bool)
+  - [PhotoMaxWidth](https://github.com/AnyImageProject/AnyImageKit/wiki/Picker%E4%BD%BF%E7%94%A8%E8%AF%B4%E6%98%8E#photomaxwidth-cgfloat)
+  - [LargePhotoMaxWidth](https://github.com/AnyImageProject/AnyImageKit/wiki/Picker%E4%BD%BF%E7%94%A8%E8%AF%B4%E6%98%8E#largephotomaxwidth-cgfloat)
+  - ~~[QuickPick](https://github.com/AnyImageProject/AnyImageKit/wiki/Picker%E4%BD%BF%E7%94%A8%E8%AF%B4%E6%98%8E#quickpick-bool)~~
+  - [AlbumOptions](https://github.com/AnyImageProject/AnyImageKit/wiki/Picker%E4%BD%BF%E7%94%A8%E8%AF%B4%E6%98%8E#albumoptions-pickeralbumoption)
+  - [SelectOptions](https://github.com/AnyImageProject/AnyImageKit/wiki/Picker%E4%BD%BF%E7%94%A8%E8%AF%B4%E6%98%8E#selectoptions-pickerselectoption)
+  - [SelectionTapAction](https://github.com/AnyImageProject/AnyImageKit/wiki/Picker%E4%BD%BF%E7%94%A8%E8%AF%B4%E6%98%8E#selectiontapaction-pickerselectiontapaction)
+  - [OrderByDate](https://github.com/AnyImageProject/AnyImageKit/wiki/Picker%E4%BD%BF%E7%94%A8%E8%AF%B4%E6%98%8E#orderbydate-sort)
+  - [PreselectAssets](https://github.com/AnyImageProject/AnyImageKit/wiki/Picker%E4%BD%BF%E7%94%A8%E8%AF%B4%E6%98%8E#preselectassets-string)
+  - [SaveEditedAsset](https://github.com/AnyImageProject/AnyImageKit/wiki/Picker%E4%BD%BF%E7%94%A8%E8%AF%B4%E6%98%8E#saveeditedasset-bool)
+  - [EditorOptions](https://github.com/AnyImageProject/AnyImageKit/wiki/Picker%E4%BD%BF%E7%94%A8%E8%AF%B4%E6%98%8E#editoroptions-pickereditoroption)
+  - [EditorPhotoOptions](https://github.com/AnyImageProject/AnyImageKit/wiki/Picker%E4%BD%BF%E7%94%A8%E8%AF%B4%E6%98%8E#editorphotooptions-editorphotooptionsinfo)
+  - [CaptureOptions](https://github.com/AnyImageProject/AnyImageKit/wiki/Picker%E4%BD%BF%E7%94%A8%E8%AF%B4%E6%98%8E#captureoptions-captureoptionsinfo)
+  - [UseSameEditorOptionsInCapture](https://github.com/AnyImageProject/AnyImageKit/wiki/Picker%E4%BD%BF%E7%94%A8%E8%AF%B4%E6%98%8E#usesameeditoroptionsincapture-bool)
+- [公开方法](https://github.com/AnyImageProject/AnyImageKit/wiki/Picker%E4%BD%BF%E7%94%A8%E8%AF%B4%E6%98%8E#%E5%85%AC%E5%BC%80%E6%96%B9%E6%B3%95)
+  - [获取原始图片](https://github.com/AnyImageProject/AnyImageKit/wiki/Picker%E4%BD%BF%E7%94%A8%E8%AF%B4%E6%98%8E#%E8%8E%B7%E5%8F%96%E5%8E%9F%E5%A7%8B%E5%9B%BE%E7%89%87)
+  - [获取视频](https://github.com/AnyImageProject/AnyImageKit/wiki/Picker%E4%BD%BF%E7%94%A8%E8%AF%B4%E6%98%8E#%E8%8E%B7%E5%8F%96%E8%A7%86%E9%A2%91)
+
+
+
 ## 调用/回调说明
 
 `ImagePickerController` 的使用方式与 `UIImagePickerController` 非常类似。
@@ -121,13 +149,15 @@ func imagePicker(_ picker: ImagePickerController, didFinishPicking result: Picke
 
 
 
-### QuickPick (Bool)
+### ~~QuickPick (Bool)~~
 
-`quickPick` 是否允许快速选择，默认关闭。
+~~`quickPick` 是否允许快速选择，默认关闭。~~
 
-当开始此属性时，点击图片将直接选中图片，而不会进入预览页面。
+~~当开始此属性时，点击图片将直接选中图片，而不会进入预览页面。~~
 
-当开启此属性且 `selectLimit` 为 1 时，点击图片将直接退出 picker 并触发回调。
+~~当开启此属性且 `selectLimit` 为 1 时，点击图片将直接退出 picker 并触发回调。~~
+
+请使用 `selectionTapAction` 并设置为 `quickPick` 来代替该属性。
 
 
 
@@ -173,6 +203,29 @@ struct PickerSelectOption: OptionSet {
 
 
 
+### SelectionTapAction (PickerSelectionTapAction)
+
+`PickerSelectionTapAction` 是在资源列表点击资源后的动作，默认为 `.preview`。
+
+```swift
+enum PickerSelectionTapAction: Equatable {
+    /// Preview 预览
+    case preview
+    /// Quick pick 快速选择
+    case quickPick
+    /// Open editor 打开编辑器
+    case openEditor
+}
+```
+
+当设置为 `preview` 时，点击会打开预览控制器。
+
+当设置为 `quickPick` 时，点击会直接选中该资源。
+
+当设置为 `openEditor` 时，点击会直接打开编辑器。
+
+
+
 ### OrderByDate (Sort)
 
 `orderByDate` 是排序的类型，默认为 `.asc`。
@@ -199,6 +252,12 @@ enum Sort: Equatable {
 接收 `Asset.identifier` 字符串，设置之后打开 `Picker` 会选中该资源。
 
 具体使用方式可以在 `Example - PreselectAsset` 控制器中查看。
+
+
+
+### SaveEditedAsset (Bool)
+
+`saveEditedAsset` 是否保存编辑后的资源，默认为 `true`。
 
 
 

--- a/Example/Controller/Application/AvatarPickerController.swift
+++ b/Example/Controller/Application/AvatarPickerController.swift
@@ -35,7 +35,13 @@ final class AvatarPickerController: UITableViewController {
         var options = PickerOptionsInfo()
         options.selectLimit = 1
         options.quickPick = true
+        options.saveEditedAsset = false
+        options.openEditorAfterSelection = true
+        options.editorOptions = [.photo]
+        options.editorPhotoOptions.toolOptions = [.crop]
+        options.editorPhotoOptions.cropOptions = [.custom(w: 1, h: 1)]
         let controller = ImagePickerController(options: options, delegate: self)
+        controller.modalPresentationStyle = .fullScreen
         present(controller, animated: true, completion: nil)
     }
     
@@ -75,31 +81,10 @@ final class AvatarPickerController: UITableViewController {
 extension AvatarPickerController: ImagePickerControllerDelegate {
     
     func imagePicker(_ picker: ImagePickerController, didFinishPicking result: PickerResult) {
-        var options = EditorPhotoOptionsInfo()
-        options.toolOptions = [.crop]
-        options.cropOptions = [.custom(w: 1, h: 1)]
-        let editor = ImageEditorController(photo: result.assets.first!.image, options: options, delegate: self)
-        picker.present(editor, animated: false, completion: nil)
-    }
-}
-
-// MARK: - ImageEditorPhotoDelegate
-extension AvatarPickerController: ImageEditorControllerDelegate {
-    
-    func imageEditorDidCancel(_ editor: ImageEditorController) {
-        editor.presentingViewController?.presentingViewController?.dismiss(animated: true, completion: nil)
-        openPickerTapped()
-    }
-    
-    func imageEditor(_ editor: ImageEditorController, didFinishEditing result: EditorResult) {
-        if result.type == .photo {
-            guard let photoData = try? Data(contentsOf: result.mediaURL) else { return }
-            guard let photo = UIImage(data: photoData) else { return }
-            let controller = EditorResultViewController()
-            controller.imageView.image = photo
-            show(controller, sender: nil)
-            editor.presentingViewController?.presentingViewController?.dismiss(animated: false, completion: nil)
-        }
+        picker.dismiss(animated: true, completion: nil)
+        let controller = EditorResultViewController()
+        controller.imageView.image = result.assets.first!.image
+        show(controller, sender: nil)
     }
 }
 
@@ -109,14 +94,11 @@ extension AvatarPickerController {
     // MARK: - Section
     enum Section: Int, CaseIterable {
         case pickerConfig = 0
-        case editorConfig
         
         var title: String {
             switch self {
             case .pickerConfig:
                 return "Picker config"
-            case .editorConfig:
-                return "Editor config"
             }
         }
         
@@ -124,8 +106,6 @@ extension AvatarPickerController {
             switch self {
             case .pickerConfig:
                 return PickerConfigRowType.allCases
-            case .editorConfig:
-                return EditorConfigRowType.allCases
             }
         }
     }
@@ -134,6 +114,11 @@ extension AvatarPickerController {
     enum PickerConfigRowType: Int, CaseIterable, RowTypeRule {
         case selectLimit = 0
         case quickPick
+        case editorOptions
+        case saveEditedAsset
+        case openEditorAfterSelection
+        case editorPhotoOptions_editOptions
+        case editorPhotoOptions_cropOptions
         
         var title: String {
             switch self {
@@ -141,6 +126,16 @@ extension AvatarPickerController {
                 return "SelectLimit"
             case .quickPick:
                 return "QuickPick"
+            case .saveEditedAsset:
+                return "SaveEditedAsset"
+            case .openEditorAfterSelection:
+                return "OpenEditorAfterSelection"
+            case .editorOptions:
+                return "EditorOptions"
+            case .editorPhotoOptions_editOptions:
+                return "EditOptions"
+            case .editorPhotoOptions_cropOptions:
+                return "CropOptions"
             }
         }
         
@@ -150,6 +145,16 @@ extension AvatarPickerController {
                 return ".selectLimit"
             case .quickPick:
                 return ".quickPick"
+            case .saveEditedAsset:
+                return ".saveEditedAsset"
+            case .openEditorAfterSelection:
+                return ".openEditorAfterSelection"
+            case .editorOptions:
+                return ".editorOptions"
+            case .editorPhotoOptions_editOptions:
+                return ".editorPhotoOptions.editOptions"
+            case .editorPhotoOptions_cropOptions:
+                return ".editorPhotoOptions.cropOptions"
             }
         }
         
@@ -159,38 +164,15 @@ extension AvatarPickerController {
                 return "1"
             case .quickPick:
                 return "true"
-            }
-        }
-    }
-    
-    // MARK: - Editor Config
-    enum EditorConfigRowType: Int, CaseIterable, RowTypeRule {
-        case editOptions = 0
-        case cropOptions
-        
-        var title: String {
-            switch self {
-            case .editOptions:
-                return "EditOptions"
-            case .cropOptions:
-                return "CropOptions"
-            }
-        }
-        
-        var options: String {
-            switch self {
-            case .editOptions:
-                return ".editOptions"
-            case .cropOptions:
-                return ".cropOptions"
-            }
-        }
-        
-        var defaultValue: String {
-            switch self {
-            case .editOptions:
+            case .saveEditedAsset:
+                return "false"
+            case .openEditorAfterSelection:
+                return "true"
+            case .editorOptions:
+                return "Photo"
+            case .editorPhotoOptions_editOptions:
                 return "Crop"
-            case .cropOptions:
+            case .editorPhotoOptions_cropOptions:
                 return "1:1"
             }
         }

--- a/Example/Controller/Application/AvatarPickerController.swift
+++ b/Example/Controller/Application/AvatarPickerController.swift
@@ -34,9 +34,8 @@ final class AvatarPickerController: UITableViewController {
     @IBAction func openPickerTapped() {
         var options = PickerOptionsInfo()
         options.selectLimit = 1
-        options.quickPick = true
+        options.selectionTapAction = .openEditor
         options.saveEditedAsset = false
-        options.openEditorAfterSelection = true
         options.editorOptions = [.photo]
         options.editorPhotoOptions.toolOptions = [.crop]
         options.editorPhotoOptions.cropOptions = [.custom(w: 1, h: 1)]
@@ -113,10 +112,9 @@ extension AvatarPickerController {
     // MARK: - Picker Config
     enum PickerConfigRowType: Int, CaseIterable, RowTypeRule {
         case selectLimit = 0
-        case quickPick
+        case selectionTapAction
         case editorOptions
         case saveEditedAsset
-        case openEditorAfterSelection
         case editorPhotoOptions_editOptions
         case editorPhotoOptions_cropOptions
         
@@ -124,12 +122,10 @@ extension AvatarPickerController {
             switch self {
             case .selectLimit:
                 return "SelectLimit"
-            case .quickPick:
-                return "QuickPick"
+            case .selectionTapAction:
+                return "SelectionTapAction"
             case .saveEditedAsset:
                 return "SaveEditedAsset"
-            case .openEditorAfterSelection:
-                return "OpenEditorAfterSelection"
             case .editorOptions:
                 return "EditorOptions"
             case .editorPhotoOptions_editOptions:
@@ -143,12 +139,10 @@ extension AvatarPickerController {
             switch self {
             case .selectLimit:
                 return ".selectLimit"
-            case .quickPick:
-                return ".quickPick"
+            case .selectionTapAction:
+                return ".selectionTapAction"
             case .saveEditedAsset:
                 return ".saveEditedAsset"
-            case .openEditorAfterSelection:
-                return ".openEditorAfterSelection"
             case .editorOptions:
                 return ".editorOptions"
             case .editorPhotoOptions_editOptions:
@@ -162,12 +156,10 @@ extension AvatarPickerController {
             switch self {
             case .selectLimit:
                 return "1"
-            case .quickPick:
-                return "true"
+            case .selectionTapAction:
+                return "OpenEditor"
             case .saveEditedAsset:
                 return "false"
-            case .openEditorAfterSelection:
-                return "true"
             case .editorOptions:
                 return "Photo"
             case .editorPhotoOptions_editOptions:

--- a/Example/Controller/PickerConfigViewController.swift
+++ b/Example/Controller/PickerConfigViewController.swift
@@ -161,9 +161,22 @@ extension PickerConfigViewController {
         (tableView.cellForRow(at: indexPath) as? ConfigCell)?.contentLabel.text = "\(options.allowUseOriginalImage)"
     }
     
-    private func quickPickTapped(_ indexPath: IndexPath) {
-        options.quickPick = !options.quickPick
-        (tableView.cellForRow(at: indexPath) as? ConfigCell)?.contentLabel.text = "\(options.quickPick)"
+    private func selectionTapActionTapped(_ indexPath: IndexPath) {
+        let alert = UIAlertController(title: "Selection Tap Action", message: nil, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "Preview", style: .default, handler: { [weak self] (action) in
+            self?.options.selectionTapAction = .preview
+            (self?.tableView.cellForRow(at: indexPath) as? ConfigCell)?.contentLabel.text = action.title
+        }))
+        alert.addAction(UIAlertAction(title: "Quick Pick", style: .default, handler: { [weak self] (action) in
+            self?.options.selectionTapAction = .quickPick
+            (self?.tableView.cellForRow(at: indexPath) as? ConfigCell)?.contentLabel.text = action.title
+        }))
+        alert.addAction(UIAlertAction(title: "Open Editor", style: .default, handler: { [weak self] (action) in
+            self?.options.selectionTapAction = .openEditor
+            (self?.tableView.cellForRow(at: indexPath) as? ConfigCell)?.contentLabel.text = action.title
+        }))
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        present(alert, animated: true, completion: nil)
     }
     
     private func albumOptionsTapped(_ indexPath: IndexPath) {
@@ -247,11 +260,6 @@ extension PickerConfigViewController {
         (tableView.cellForRow(at: indexPath) as? ConfigCell)?.contentLabel.text = "\(options.saveEditedAsset)"
     }
     
-    private func openEditorAfterSelectionTapped(_ indexPath: IndexPath) {
-        options.openEditorAfterSelection = !options.openEditorAfterSelection
-        (tableView.cellForRow(at: indexPath) as? ConfigCell)?.contentLabel.text = "\(options.openEditorAfterSelection)"
-    }
-    
     private func captureMediaOptionsTapped(_ indexPath: IndexPath) {
         let alert = UIAlertController(title: "Capture Options", message: nil, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "None", style: .default, handler: { [weak self] (action) in
@@ -325,7 +333,7 @@ extension PickerConfigViewController {
         case selectLimit
         case columnNumber
         case allowUseOriginalImage
-        case quickPick
+        case selectionTapAction
         case albumOptions
         case selectOptions
         case orderByDate
@@ -340,8 +348,8 @@ extension PickerConfigViewController {
                 return "ColumnNumber"
             case .allowUseOriginalImage:
                 return "UseOriginalImage"
-            case .quickPick:
-                return "QuickPick"
+            case .selectionTapAction:
+                return "SelectionTapAction"
             case .albumOptions:
                 return "AlbumOptions"
             case .selectOptions:
@@ -361,8 +369,8 @@ extension PickerConfigViewController {
                 return ".columnNumber"
             case .allowUseOriginalImage:
                 return ".allowUseOriginalImage"
-            case .quickPick:
-                return ".quickPick"
+            case .selectionTapAction:
+                return ".selectionTapAction"
             case .albumOptions:
                 return ".albumOptions"
             case .selectOptions:
@@ -382,8 +390,8 @@ extension PickerConfigViewController {
                 return "4"
             case .allowUseOriginalImage:
                 return "false"
-            case .quickPick:
-                return "false"
+            case .selectionTapAction:
+                return "Preview"
             case .albumOptions:
                 return "Smart+User Created"
             case .selectOptions:
@@ -404,8 +412,8 @@ extension PickerConfigViewController {
                 return controller.columnNumberTapped
             case .allowUseOriginalImage:
                 return controller.allowUseOriginalImageTapped
-            case .quickPick:
-                return controller.quickPickTapped
+            case .selectionTapAction:
+                return controller.selectionTapActionTapped
             case .albumOptions:
                 return controller.albumOptionsTapped
             case .selectOptions:
@@ -420,7 +428,6 @@ extension PickerConfigViewController {
     enum EditorConfigRowType: Int, CaseIterable, RowTypeRule {
         case editorOptions = 0
         case saveEditedAsset
-        case openEditorAfterSelection
         
         var title: String {
             switch self {
@@ -428,8 +435,6 @@ extension PickerConfigViewController {
                 return "EditorOptions"
             case .saveEditedAsset:
                 return "SaveEditedAsset"
-            case .openEditorAfterSelection:
-                return "OpenEditorAfterSelection"
             }
         }
         
@@ -439,8 +444,6 @@ extension PickerConfigViewController {
                 return ".editorOptions"
             case .saveEditedAsset:
                 return ".saveEditedAsset"
-            case .openEditorAfterSelection:
-                return ".openEditorAfterSelection"
             }
         }
         
@@ -450,8 +453,6 @@ extension PickerConfigViewController {
                 return "None"
             case .saveEditedAsset:
                 return "true"
-            case .openEditorAfterSelection:
-                return "false"
             }
         }
         
@@ -462,8 +463,6 @@ extension PickerConfigViewController {
                 return controller.editorOptionsTapped
             case .saveEditedAsset:
                 return controller.saveEditedAssetTapped
-            case .openEditorAfterSelection:
-                return controller.openEditorAfterSelectionTapped
             }
         }
     }

--- a/Example/Controller/PickerConfigViewController.swift
+++ b/Example/Controller/PickerConfigViewController.swift
@@ -242,6 +242,16 @@ extension PickerConfigViewController {
         present(alert, animated: true, completion: nil)
     }
     
+    private func saveEditedAssetTapped(_ indexPath: IndexPath) {
+        options.saveEditedAsset = !options.saveEditedAsset
+        (tableView.cellForRow(at: indexPath) as? ConfigCell)?.contentLabel.text = "\(options.saveEditedAsset)"
+    }
+    
+    private func openEditorAfterSelectionTapped(_ indexPath: IndexPath) {
+        options.openEditorAfterSelection = !options.openEditorAfterSelection
+        (tableView.cellForRow(at: indexPath) as? ConfigCell)?.contentLabel.text = "\(options.openEditorAfterSelection)"
+    }
+    
     private func captureMediaOptionsTapped(_ indexPath: IndexPath) {
         let alert = UIAlertController(title: "Capture Options", message: nil, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "None", style: .default, handler: { [weak self] (action) in
@@ -409,11 +419,17 @@ extension PickerConfigViewController {
     // MARK: - Editor Config
     enum EditorConfigRowType: Int, CaseIterable, RowTypeRule {
         case editorOptions = 0
+        case saveEditedAsset
+        case openEditorAfterSelection
         
         var title: String {
             switch self {
             case .editorOptions:
                 return "EditorOptions"
+            case .saveEditedAsset:
+                return "SaveEditedAsset"
+            case .openEditorAfterSelection:
+                return "OpenEditorAfterSelection"
             }
         }
         
@@ -421,6 +437,10 @@ extension PickerConfigViewController {
             switch self {
             case .editorOptions:
                 return ".editorOptions"
+            case .saveEditedAsset:
+                return ".saveEditedAsset"
+            case .openEditorAfterSelection:
+                return ".openEditorAfterSelection"
             }
         }
         
@@ -428,6 +448,10 @@ extension PickerConfigViewController {
             switch self {
             case .editorOptions:
                 return "None"
+            case .saveEditedAsset:
+                return "true"
+            case .openEditorAfterSelection:
+                return "false"
             }
         }
         
@@ -436,6 +460,10 @@ extension PickerConfigViewController {
             switch self {
             case .editorOptions:
                 return controller.editorOptionsTapped
+            case .saveEditedAsset:
+                return controller.saveEditedAssetTapped
+            case .openEditorAfterSelection:
+                return controller.openEditorAfterSelectionTapped
             }
         }
     }

--- a/Example/Resources/en.lproj/Localizable.strings
+++ b/Example/Resources/en.lproj/Localizable.strings
@@ -16,6 +16,8 @@
 "SelectOptions" = "Select Options";
 "AlbumOptions" = "Album Options";
 "OrderByDate" = "Order By Date";
+"SaveEditedAsset" = "Save edited asset";
+"OpenEditorAfterSelection" = "Open editor after selection";
 "EditorOptions" = "Editor Options";
 "CaptureOptions" = "Capture Options";
 "FullScreen" = "Full Screen";

--- a/Example/Resources/en.lproj/Localizable.strings
+++ b/Example/Resources/en.lproj/Localizable.strings
@@ -12,12 +12,11 @@
 "SelectLimit" = "Select Limit";
 "ColumnNumber" = "Column Number";
 "UseOriginalImage" = "Use Original Image";
-"QuickPick" = "QuickPick";
+"SelectionTapAction" = "Selection Tap Action";
 "SelectOptions" = "Select Options";
 "AlbumOptions" = "Album Options";
 "OrderByDate" = "Order By Date";
 "SaveEditedAsset" = "Save edited asset";
-"OpenEditorAfterSelection" = "Open editor after selection";
 "EditorOptions" = "Editor Options";
 "CaptureOptions" = "Capture Options";
 "FullScreen" = "Full Screen";

--- a/Example/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Example/Resources/zh-Hans.lproj/Localizable.strings
@@ -12,12 +12,11 @@
 "SelectLimit" = "最多可选择的资源";
 "ColumnNumber" = "一行的列数";
 "UseOriginalImage" = "是否使用原图";
-"QuickPick" = "快速选择";
-"SelectOptions" = "选择类型";
+"SelectionTapAction" = "资源列表点击动作";
+"SelectOptions" = "资源类型";
 "AlbumOptions" = "相册类型";
 "OrderByDate" = "排序方式";
 "SaveEditedAsset" = "保存编辑后的资源";
-"OpenEditorAfterSelection" = "选择资源后打开编辑器";
 "EditorOptions" = "编辑类型";
 "CaptureOptions" = "拍摄类型";
 "FullScreen" = "是否全屏";

--- a/Example/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Example/Resources/zh-Hans.lproj/Localizable.strings
@@ -16,6 +16,8 @@
 "SelectOptions" = "选择类型";
 "AlbumOptions" = "相册类型";
 "OrderByDate" = "排序方式";
+"SaveEditedAsset" = "保存编辑后的资源";
+"OpenEditorAfterSelection" = "选择资源后打开编辑器";
 "EditorOptions" = "编辑类型";
 "CaptureOptions" = "拍摄类型";
 "FullScreen" = "是否全屏";

--- a/Sources/AnyImageKit/Picker/Controller/AssetPickerViewController+Editor.swift
+++ b/Sources/AnyImageKit/Picker/Controller/AssetPickerViewController+Editor.swift
@@ -1,0 +1,98 @@
+//
+//  AssetPickerViewController+Editor.swift
+//  AnyImageKit
+//
+//  Created by 蒋惠 on 2020/12/23.
+//  Copyright © 2020 AnyImageProject.org. All rights reserved.
+//
+
+import UIKit
+
+#if ANYIMAGEKIT_ENABLE_EDITOR
+
+extension AssetPickerViewController {
+    
+    func canOpenEditor(with asset: Asset) -> Bool {
+        asset.check(disable: manager.options.disableRules)
+        if case .disable(let rule) = asset.state {
+            let message = rule.alertMessage(for: asset)
+            showAlert(message: message)
+            return false
+        }
+        if asset.phAsset.mediaType == .image && manager.options.editorOptions.contains(.photo) {
+            return true
+        } else if asset.phAsset.mediaType == .video && manager.options.editorOptions.contains(.video) {
+            return true
+        }
+        return false
+    }
+    
+    func openEditor(with asset: Asset, indexPath: IndexPath) {
+        if asset.phAsset.mediaType == .image {
+            if let image = asset._images[.initial] {
+                showEditor(image, identifier: asset.phAsset.localIdentifier, tag: indexPath.item)
+            } else {
+                showWaitHUD()
+                let options = _PhotoFetchOptions(sizeMode: .preview(manager.options.largePhotoMaxWidth))
+                manager.requestPhoto(for: asset.phAsset, options: options) { [weak self] result in
+                    guard let self = self else { return }
+                    switch result {
+                    case .success(let response):
+                        if !response.isDegraded {
+                            hideHUD()
+                            self.showEditor(response.image, identifier: asset.phAsset.localIdentifier, tag: indexPath.item)
+                        }
+                    case .failure(let error):
+                        hideHUD()
+                        _print(error)
+                    }
+                }
+            }
+        } else if asset.phAsset.mediaType == .video {
+            manager.cancelFetch(for: asset.phAsset.localIdentifier)
+            var videoOptions = manager.options.editorVideoOptions
+            videoOptions.enableDebugLog = manager.options.enableDebugLog
+            let image = asset._images[.initial]
+            let controller = ImageEditorController(video: asset.phAsset, placeholderImage: image, options: videoOptions, delegate: self)
+            present(controller, animated: false, completion: nil)
+        }
+    }
+    
+    private func showEditor(_ image: UIImage, identifier: String, tag: Int) {
+        var options = manager.options.editorPhotoOptions
+        options.enableDebugLog = manager.options.enableDebugLog
+        options.cacheIdentifier = identifier.replacingOccurrences(of: "/", with: "-")
+        let controller = ImageEditorController(photo: image, options: options, delegate: self)
+        controller.tag = tag
+        present(controller, animated: true, completion: nil)
+    }
+}
+
+// MARK: - ImageEditorControllerDelegate
+extension AssetPickerViewController: ImageEditorControllerDelegate {
+    
+    func imageEditorDidCancel(_ editor: ImageEditorController) {
+        editor.dismiss(animated: true, completion: nil)
+    }
+    
+    func imageEditor(_ editor: ImageEditorController, didFinishEditing result: EditorResult) {
+        editor.dismiss(animated: true, completion: nil)
+        guard result.type == .photo else { return }
+        guard let photoData = try? Data(contentsOf: result.mediaURL) else { return }
+        guard let photo = UIImage(data: photoData) else { return }
+        guard let album = album else { return }
+        guard let cell = collectionView.cellForItem(at: IndexPath(item: editor.tag, section: 0)) as? AssetCell else { return }
+        
+        let asset = album.assets[editor.tag]
+        asset._images[.edited] = result.isEdited ? photo : nil
+        cell.setContent(asset, manager: manager)
+        if !asset.isSelected { // Select
+            selectItem(editor.tag)
+            if manager.options.selectLimit == 1 && manager.selectedAssets.count == 1 {
+                doneButtonTapped(toolBar.doneButton)
+            }
+        }
+    }
+}
+
+#endif

--- a/Sources/AnyImageKit/Picker/Controller/AssetPickerViewController.swift
+++ b/Sources/AnyImageKit/Picker/Controller/AssetPickerViewController.swift
@@ -617,7 +617,7 @@ extension AssetPickerViewController: PhotoPreviewControllerDataSource {
     func previewController(_ controller: PhotoPreviewController, thumbnailViewForIndex index: Int) -> UIView? {
         let idx = index + itemOffset
         let indexPath = IndexPath(item: idx, section: 0)
-        return collectionView.cellForItem(at: indexPath)
+        return collectionView.cellForItem(at: indexPath) ?? toolBar.leftButton
     }
 }
 

--- a/Sources/AnyImageKit/Picker/Controller/AssetPickerViewController.swift
+++ b/Sources/AnyImageKit/Picker/Controller/AssetPickerViewController.swift
@@ -46,7 +46,7 @@ final class AssetPickerViewController: AnyImageViewController {
         layout.minimumInteritemSpacing = defaultAssetSpacing
         let view = UICollectionView(frame: .zero, collectionViewLayout: layout)
         view.alwaysBounceVertical = true
-        let hideToolBar = manager.options.quickPick && manager.options.selectLimit == 1
+        let hideToolBar = manager.options.selectionTapAction.hideToolBar && manager.options.selectLimit == 1
         view.contentInset = UIEdgeInsets(top: defaultAssetSpacing,
                                          left: defaultAssetSpacing,
                                          bottom: defaultAssetSpacing + (hideToolBar ? 0 : toolBarHeight),
@@ -72,7 +72,7 @@ final class AssetPickerViewController: AnyImageViewController {
         view.originalButton.addTarget(self, action: #selector(originalImageButtonTapped(_:)), for: .touchUpInside)
         view.doneButton.addTarget(self, action: #selector(doneButtonTapped(_:)), for: .touchUpInside)
         view.permissionLimitedView.limitedButton.addTarget(self, action: #selector(limitedButtonTapped(_:)), for: .touchUpInside)
-        view.isHidden = manager.options.quickPick && manager.options.selectLimit == 1
+        view.isHidden = manager.options.selectionTapAction.hideToolBar && manager.options.selectLimit == 1
         return view
     }()
     
@@ -270,7 +270,7 @@ extension AssetPickerViewController {
     
     private func showLimitedView() {
         if #available(iOS 14.0, *) {
-            let hideToolBar = manager.options.quickPick && manager.options.selectLimit == 1
+            let hideToolBar = manager.options.selectionTapAction.hideToolBar && manager.options.selectLimit == 1
             let newToolBarHeight = (hideToolBar ? 0 : toolBarHeight) + toolBar.limitedViewHeight
             toolBar.isHidden = false
             toolBar.contentView.isHidden = hideToolBar
@@ -375,7 +375,7 @@ extension AssetPickerViewController {
     
     @objc private func didSyncAsset(_ sender: Notification) {
         guard let _ = sender.object as? String else { return }
-        guard manager.options.selectLimit == 1 && manager.options.quickPick else { return }
+        guard manager.options.selectLimit == 1 && manager.options.selectionTapAction.hideToolBar else { return }
         guard let asset = manager.selectedAssets.first else { return }
         guard let cell = collectionView.cellForItem(at: IndexPath(row: asset.idx, section: 0)) as? AssetCell else { return }
         selectButtonTapped(cell.selectButton)
@@ -526,13 +526,13 @@ extension AssetPickerViewController: UICollectionViewDelegate {
         }
         #endif
         #if ANYIMAGEKIT_ENABLE_EDITOR
-        if manager.options.openEditorAfterSelection && canOpenEditor(with: asset) {
+        if manager.options.selectionTapAction == .openEditor && canOpenEditor(with: asset) {
             openEditor(with: asset, indexPath: indexPath)
             return
         }
         #endif
         
-        if manager.options.quickPick {
+        if manager.options.selectionTapAction == .quickPick {
             guard let cell = collectionView.cellForItem(at: indexPath) as? AssetCell else { return }
             selectButtonTapped(cell.selectButton)
             if manager.options.selectLimit == 1 && manager.selectedAssets.count == 1 {

--- a/Sources/AnyImageKit/Picker/Controller/ImagePickerController.swift
+++ b/Sources/AnyImageKit/Picker/Controller/ImagePickerController.swift
@@ -146,12 +146,6 @@ extension ImagePickerController {
         }
         #endif
         
-        #if ANYIMAGEKIT_ENABLE_EDITOR
-        if options.openEditorAfterSelection {
-            options.quickPick = true
-        }
-        #endif
-        
         #if DEBUG
         assert(options.selectLimit >= 1, "Select limit should more then 1")
         #else

--- a/Sources/AnyImageKit/Picker/Controller/ImagePickerController.swift
+++ b/Sources/AnyImageKit/Picker/Controller/ImagePickerController.swift
@@ -146,6 +146,12 @@ extension ImagePickerController {
         }
         #endif
         
+        #if ANYIMAGEKIT_ENABLE_EDITOR
+        if options.openEditorAfterSelection {
+            options.quickPick = true
+        }
+        #endif
+        
         #if DEBUG
         assert(options.selectLimit >= 1, "Select limit should more then 1")
         #else
@@ -162,10 +168,6 @@ extension ImagePickerController {
         
         if options.selectLimit < options.preselectAssets.count {
             options.preselectAssets.removeLast(options.preselectAssets.count-options.selectLimit)
-        }
-        
-        if options.openEditorAfterSelection {
-            options.quickPick = true
         }
         
         return options

--- a/Sources/AnyImageKit/Picker/Controller/ImagePickerController.swift
+++ b/Sources/AnyImageKit/Picker/Controller/ImagePickerController.swift
@@ -164,6 +164,10 @@ extension ImagePickerController {
             options.preselectAssets.removeLast(options.preselectAssets.count-options.selectLimit)
         }
         
+        if options.openEditorAfterSelection {
+            options.quickPick = true
+        }
+        
         return options
     }
     
@@ -187,6 +191,11 @@ extension ImagePickerController {
     }
     
     private func saveEditPhotos(_ assets: [Asset], completion: @escaping (([Asset]) -> Void)) {
+        #if ANYIMAGEKIT_ENABLE_EDITOR
+        guard manager.options.saveEditedAsset else {
+            completion(assets)
+            return
+        }
         var assets = assets
         let selectOptions = manager.options.selectOptions
         let group = DispatchGroup()
@@ -207,6 +216,9 @@ extension ImagePickerController {
         group.notify(queue: workQueue) {
             completion(assets)
         }
+        #else
+        completion(assets)
+        #endif
     }
     
     private func resizeImagesIfNeeded(_ assets: [Asset]) {

--- a/Sources/AnyImageKit/Picker/PickerOptionsInfo.swift
+++ b/Sources/AnyImageKit/Picker/PickerOptionsInfo.swift
@@ -76,6 +76,17 @@ public struct PickerOptionsInfo {
     public var enableDebugLog: Bool = false
     
     #if ANYIMAGEKIT_ENABLE_EDITOR
+    /// Save edited asset when picker dismiss with success
+    /// - Default: true
+    /// - 完成选择后保存编辑过的资源
+    public var saveEditedAsset: Bool = true
+    
+    /// Open editor after selection
+    /// - Default: false
+    /// - It will open Editor instead of show preview controller when you click photo on asset picker controller
+    /// - 点击图片后会进入编辑器，而不会进入预览页面
+    public var openEditorAfterSelection: Bool = false
+    
     /// Editor Options 可编辑资源类型
     /// - Default: []
     public var editorOptions: PickerEditorOption = []

--- a/Sources/AnyImageKit/Picker/PickerOptionsInfo.swift
+++ b/Sources/AnyImageKit/Picker/PickerOptionsInfo.swift
@@ -41,10 +41,6 @@ public struct PickerOptionsInfo {
     /// - Default: false
     public var allowUseOriginalImage: Bool = false
     
-    /// Selection Tap Action 资源列表点击动作
-    /// - Default: Preview
-    public var selectionTapAction: PickerSelectionTapAction = .preview
-    
     /// Album Options 相册类型
     /// - Default: smart album + user create album
     public var albumOptions: PickerAlbumOption = [.smart, .userCreated]
@@ -54,6 +50,10 @@ public struct PickerOptionsInfo {
     /// - .photoLive and .photoGIF are subtype of .photo and will be treated as a photo when not explicitly indicated, otherwise special handling will be possible (playable & proprietary)
     /// - .photoLive 和 .photoGIF 是 .photo 的子项，当不显式指明时，都会作为 photo 处理，否则会特殊处理（可播放&专有标识）
     public var selectOptions: PickerSelectOption = [.photo]
+    
+    /// Selection Tap Action 资源列表点击动作
+    /// - Default: Preview
+    public var selectionTapAction: PickerSelectionTapAction = .preview
     
     /// Order by date 按日期排序
     /// - Default: ASC
@@ -162,16 +162,16 @@ public struct PickerEditorOption: OptionSet {
     }
 }
 
-/// Picker Pick Mode 选择类型
-public enum PickerSelectionTapAction {
-    /// Preview
+/// Picker Selection Tap Action 资源列表点击动作
+public enum PickerSelectionTapAction: Equatable {
+    /// Preview 预览
     /// - Default value
     case preview
-    /// Quick 快速选择
+    /// Quick pick 快速选择
     /// - It will select photo instead of show preview controller when you click photo on asset picker controller
     /// - 点击图片时会直接选中该图片，而不会进入预览页面
     case quickPick
-    /// Editor
+    /// Open editor 打开编辑器
     /// - It will open Editor instead of show preview controller when you click photo on asset picker controller
     /// - 点击图片后会进入编辑器，而不会进入预览页面
     case openEditor

--- a/Sources/AnyImageKit/Picker/PickerOptionsInfo.swift
+++ b/Sources/AnyImageKit/Picker/PickerOptionsInfo.swift
@@ -41,11 +41,9 @@ public struct PickerOptionsInfo {
     /// - Default: false
     public var allowUseOriginalImage: Bool = false
     
-    /// Quick pick 快速选择
-    /// - Default: false
-    /// - It will select photo instead of show preview controller when you click photo on asset picker controller
-    /// - 点击图片时会直接选中该图片，而不会进入预览页面
-    public var quickPick: Bool = false
+    /// Selection Tap Action 资源列表点击动作
+    /// - Default: Preview
+    public var selectionTapAction: PickerSelectionTapAction = .preview
     
     /// Album Options 相册类型
     /// - Default: smart album + user create album
@@ -80,12 +78,6 @@ public struct PickerOptionsInfo {
     /// - Default: true
     /// - 完成选择后保存编辑过的资源
     public var saveEditedAsset: Bool = true
-    
-    /// Open editor after selection
-    /// - Default: false
-    /// - It will open Editor instead of show preview controller when you click photo on asset picker controller
-    /// - 点击图片后会进入编辑器，而不会进入预览页面
-    public var openEditorAfterSelection: Bool = false
     
     /// Editor Options 可编辑资源类型
     /// - Default: []
@@ -168,6 +160,21 @@ public struct PickerEditorOption: OptionSet {
     public init(rawValue: Int) {
         self.rawValue = rawValue
     }
+}
+
+/// Picker Pick Mode 选择类型
+public enum PickerSelectionTapAction {
+    /// Preview
+    /// - Default value
+    case preview
+    /// Quick 快速选择
+    /// - It will select photo instead of show preview controller when you click photo on asset picker controller
+    /// - 点击图片时会直接选中该图片，而不会进入预览页面
+    case quickPick
+    /// Editor
+    /// - It will open Editor instead of show preview controller when you click photo on asset picker controller
+    /// - 点击图片后会进入编辑器，而不会进入预览页面
+    case openEditor
 }
 
 /// UI Theme 主题
@@ -259,5 +266,17 @@ extension PickerSelectOption {
             result.append(.video)
         }
         return result
+    }
+}
+
+extension PickerSelectionTapAction {
+    
+    var hideToolBar: Bool {
+        switch self {
+        case .quickPick, .openEditor:
+            return true
+        default:
+            return false
+        }
     }
 }

--- a/Sources/AnyImageKit/Picker/View/Cell/AssetCell.swift
+++ b/Sources/AnyImageKit/Picker/View/Cell/AssetCell.swift
@@ -126,7 +126,7 @@ extension AssetCell {
     private func setOptions(_ options: PickerOptionsInfo) {
         boxCoverView.layer.borderColor = options.theme.mainColor.cgColor
         selectButton.setTheme(options.theme)
-        selectButton.isHidden = options.quickPick && options.selectLimit == 1
+        selectButton.isHidden = options.selectionTapAction.hideToolBar && options.selectLimit == 1
     }
     
     func setContent(_ asset: Asset, manager: PickerManager, animated: Bool = false, isPreview: Bool = false) {


### PR DESCRIPTION
完成在资源列表推出编辑器功能。 #59 

### 增加字段
`saveEditedAsset` 默认为 `true`。
- true: Picker 在完成选择后**会**保存编辑后的资源。
- false: Picker 在完成选择后**不会**保存编辑后的资源。

`openEditorAfterSelection` 默认为 `false`。
- true: Picker 在资源列表点击资源后**会**直接打开 Editor。
  - 会自动将 `quickPick` 改为 `true`。
- false: Picker 在资源列表点击资源后**不会**直接打开 Editor。

### 修复
修复资源列表控制器中首个选中的资源不在屏幕中时，点击左下角的「预览」按钮不会打开预览控制器的问题。