### PR TITLE
修复DESC排序时，数组越界问题

### DIFF
--- a/Sources/AnyImageKit/Picker/Controller/AssetPickerViewController+Capture.swift
+++ b/Sources/AnyImageKit/Picker/Controller/AssetPickerViewController+Capture.swift
@@ -37,9 +37,9 @@ extension AssetPickerViewController {
         if !options.captureOptions.mediaOptions.isEmpty {
             switch sortType {
             case .asc:
-                album.addAsset(Asset(idx: -1, asset: .init(), selectOptions: options.selectOptions), atLast: true)
+                album.addAsset(Asset(idx: Asset.cameraItemIdx, asset: .init(), selectOptions: options.selectOptions), atLast: true)
             case .desc:
-                album.insertAsset(Asset(idx: -1, asset: .init(), selectOptions: options.selectOptions), at: 0, sort: options.orderByDate)
+                album.insertAsset(Asset(idx: Asset.cameraItemIdx, asset: .init(), selectOptions: options.selectOptions), at: 0, sort: options.orderByDate)
             }
         }
     }

--- a/Sources/AnyImageKit/Picker/Controller/AssetPickerViewController.swift
+++ b/Sources/AnyImageKit/Picker/Controller/AssetPickerViewController.swift
@@ -82,18 +82,19 @@ final class AssetPickerViewController: AnyImageViewController {
         return view
     }()
     
-    private lazy var itemOffset: Int = {
+    private var itemOffset: Int {
         #if ANYIMAGEKIT_ENABLE_CAPTURE
         switch manager.options.orderByDate {
         case .asc:
             return 0
         case .desc:
-            return manager.options.captureOptions.mediaOptions.isEmpty ? 0 : 1
+            guard !manager.options.captureOptions.mediaOptions.isEmpty else { return 0 }
+            return ((album?.hasCamera ?? false) ? 1 : 0)
         }
         #else
         return 0
         #endif
-    }()
+    }
     
     let manager: PickerManager
     

--- a/Sources/AnyImageKit/Picker/Model/Album.swift
+++ b/Sources/AnyImageKit/Picker/Model/Album.swift
@@ -33,22 +33,6 @@ class Album: Equatable {
 
 extension Album {
     
-    func insertAsset(_ asset: Asset, at: Int, sort: Sort) {
-        assets.insert(asset, at: at)
-        reloadIndex(sort: sort)
-    }
-    
-    func addAsset(_ asset: Asset, atLast: Bool) {
-        if atLast {
-            assets.append(asset)
-        } else {
-            assets.insert(asset, at: assets.count-1)
-        }
-    }
-}
-
-extension Album {
-    
     private func fetchAssets(result: PHFetchResult<PHAsset>, selectOptions: PickerSelectOption) {
         var array: [Asset] = []
         let selectPhoto = selectOptions.contains(.photo)
@@ -78,6 +62,23 @@ extension Album {
             }
         }
         assets = array
+    }
+}
+
+// MARK: - Capture
+extension Album {
+    
+    func insertAsset(_ asset: Asset, at: Int, sort: Sort) {
+        assets.insert(asset, at: at)
+        reloadIndex(sort: sort)
+    }
+    
+    func addAsset(_ asset: Asset, atLast: Bool) {
+        if atLast {
+            assets.append(asset)
+        } else {
+            assets.insert(asset, at: assets.count-1)
+        }
     }
     
     private func reloadIndex(sort: Sort) {

--- a/Sources/AnyImageKit/Picker/Model/Asset.swift
+++ b/Sources/AnyImageKit/Picker/Model/Asset.swift
@@ -66,8 +66,10 @@ extension Asset {
     }
     
     var isCamera: Bool {
-        return idx == -1
+        return idx == Asset.cameraItemIdx
     }
+    
+    static let cameraItemIdx: Int = -1
 }
 
 extension Asset: Equatable {


### PR DESCRIPTION
修复 #65 中提出的问题，由于 CameraItem 仅在 smart album 中出现，当切换相册后，没有了 CameraItem 导致数据越界的问题。
