### PR TITLE
fix: invalid_export_preset_ios_11_chip_under_a10

### DIFF
--- a/Sources/AnyImageKit/Core/Model/VideoExportPreset.swift
+++ b/Sources/AnyImageKit/Core/Model/VideoExportPreset.swift
@@ -96,8 +96,11 @@ public enum VideoExportPreset: RawRepresentable, Equatable {
 
 extension VideoExportPreset {
     
-    @available(iOS 11.0, *)
     public static func isH265ExportPresetSupported() -> Bool {
-        return VTIsHardwareDecodeSupported(kCMVideoCodecType_HEVC)
+        if #available(iOS 11.0, *) {
+            return VTIsHardwareDecodeSupported(kCMVideoCodecType_HEVC)
+        } else {
+            return false
+        }
     }
 }

--- a/Sources/AnyImageKit/Core/Model/VideoExportPreset.swift
+++ b/Sources/AnyImageKit/Core/Model/VideoExportPreset.swift
@@ -7,6 +7,7 @@
 //
 
 import AVFoundation
+import VideoToolbox
 
 public enum VideoExportPreset: RawRepresentable, Equatable {
     /// H.264/AVC 640x480
@@ -40,13 +41,13 @@ public enum VideoExportPreset: RawRepresentable, Equatable {
         case .h264_3840x2160:
             return AVAssetExportPreset3840x2160
         case .h265_1920x1080:
-            if #available(iOS 11.0, *) {
+            if #available(iOS 11.0, *), VideoExportPreset.isH265ExportPresetSupported() {
                 return AVAssetExportPresetHEVC1920x1080
             } else {
                 return AVAssetExportPreset1920x1080
             }
         case .h265_3840x2160:
-            if #available(iOS 11.0, *) {
+            if #available(iOS 11.0, *), VideoExportPreset.isH265ExportPresetSupported() {
                 return AVAssetExportPresetHEVC3840x2160
             } else {
                 return AVAssetExportPreset3840x2160
@@ -90,5 +91,13 @@ public enum VideoExportPreset: RawRepresentable, Equatable {
                 return nil
             }
         }
+    }
+}
+
+extension VideoExportPreset {
+    
+    @available(iOS 11.0, *)
+    public static func isH265ExportPresetSupported() -> Bool {
+        return VTIsHardwareDecodeSupported(kCMVideoCodecType_HEVC)
     }
 }


### PR DESCRIPTION
修复使用 a10 以下设备设置 HEVC/H.265 输出时抛出 AnyImageError.invalidExportPreset 的问题，由于 a10 以下芯片不支持 HEVC 输出，会自动回滚至 H.264 的老方案。并同时添加一个辅助方法，用于检测当前设备是否支持 HEVC 输出
`VideoExportPreset.isH265ExportPresetSupported()`